### PR TITLE
#13 persist authentication

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,4 @@
-VITE_ICARE_TOKEN=your_token
-VITE_FRITZ_TOKEN=your_token
+VITE_SKYPORTAL_TOKEN=your_token_here
+VITE_SKIP_ONBOARDING=false
+VITE_SKYPORTAL_INSTANCE_NAME=your_instance_name_here
+VITE_SKYPORTAL_INSTANCE_URL=your_instance_url_here

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(':capacitor-barcode-scanner')
     implementation project(':capacitor-haptics')
     implementation project(':capacitor-keyboard')
+    implementation project(':capacitor-preferences')
     implementation project(':capacitor-status-bar')
 
 }

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -14,5 +14,8 @@ project(':capacitor-haptics').projectDir = new File('../node_modules/@capacitor/
 include ':capacitor-keyboard'
 project(':capacitor-keyboard').projectDir = new File('../node_modules/@capacitor/keyboard/android')
 
+include ':capacitor-preferences'
+project(':capacitor-preferences').projectDir = new File('../node_modules/@capacitor/preferences/android')
+
 include ':capacitor-status-bar'
 project(':capacitor-status-bar').projectDir = new File('../node_modules/@capacitor/status-bar/android')

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -15,6 +15,7 @@ def capacitor_pods
   pod 'CapacitorBarcodeScanner', :path => '../../node_modules/@capacitor/barcode-scanner'
   pod 'CapacitorHaptics', :path => '../../node_modules/@capacitor/haptics'
   pod 'CapacitorKeyboard', :path => '../../node_modules/@capacitor/keyboard'
+  pod 'CapacitorPreferences', :path => '../../node_modules/@capacitor/preferences'
   pod 'CapacitorStatusBar', :path => '../../node_modules/@capacitor/status-bar'
 end
 

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -11,6 +11,8 @@ PODS:
     - Capacitor
   - CapacitorKeyboard (6.0.0):
     - Capacitor
+  - CapacitorPreferences (6.0.1):
+    - Capacitor
   - CapacitorStatusBar (6.0.0):
     - Capacitor
   - OSBarcodeLib (1.1.0)
@@ -22,6 +24,7 @@ DEPENDENCIES:
   - "CapacitorCordova (from `../../node_modules/@capacitor/ios`)"
   - "CapacitorHaptics (from `../../node_modules/@capacitor/haptics`)"
   - "CapacitorKeyboard (from `../../node_modules/@capacitor/keyboard`)"
+  - "CapacitorPreferences (from `../../node_modules/@capacitor/preferences`)"
   - "CapacitorStatusBar (from `../../node_modules/@capacitor/status-bar`)"
 
 SPEC REPOS:
@@ -41,6 +44,8 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/haptics"
   CapacitorKeyboard:
     :path: "../../node_modules/@capacitor/keyboard"
+  CapacitorPreferences:
+    :path: "../../node_modules/@capacitor/preferences"
   CapacitorStatusBar:
     :path: "../../node_modules/@capacitor/status-bar"
 
@@ -51,9 +56,10 @@ SPEC CHECKSUMS:
   CapacitorCordova: 8c4bfdf69368512e85b1d8b724dd7546abeb30af
   CapacitorHaptics: 9ebc9363f0e9b8eb4295088a0b474530acf1859b
   CapacitorKeyboard: deacbd09d8d1029c3681197fb05d206b721d5f73
+  CapacitorPreferences: 72909b165bc7807103778ddbb86d5d8ce06abf71
   CapacitorStatusBar: 2e4369f99166125435641b1908d05f561eaba6f6
   OSBarcodeLib: ced133bc1ec073636e18c6a0553d0a5c4b90cf17
 
-PODFILE CHECKSUM: 39415e29136c338cfa2ba225e3a912c69036b605
+PODFILE CHECKSUM: 9bfd23e93829ae51783c84639f89c2ea08f0fd03
 
 COCOAPODS: 1.11.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@capacitor/haptics": "6.0.0",
         "@capacitor/ios": "^6.0.0",
         "@capacitor/keyboard": "6.0.0",
+        "@capacitor/preferences": "^6.0.1",
         "@capacitor/status-bar": "6.0.0",
         "@ionic/react": "^8.0.0",
         "@ionic/react-router": "^8.0.0",
@@ -2023,6 +2024,15 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@capacitor/keyboard/-/keyboard-6.0.0.tgz",
       "integrity": "sha512-pPX/PQWWjw5ce47kHEYv6IWlHzuhAxgXihqEAAAGLdwK3u3srgGWCljXrYS9juVBPi/lA1uK7UaUzYI0XrgxVQ==",
+      "peerDependencies": {
+        "@capacitor/core": "^6.0.0"
+      }
+    },
+    "node_modules/@capacitor/preferences": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/preferences/-/preferences-6.0.1.tgz",
+      "integrity": "sha512-5UvSK3O/tgPcQ1QyX0zYjb0uujFw+PQgYUSt6i2evf609jAIo7QG1IUZzGb6swEPCpk621wEc6R7Yq/Ywa3GPA==",
+      "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@capacitor/haptics": "6.0.0",
     "@capacitor/ios": "^6.0.0",
     "@capacitor/keyboard": "6.0.0",
+    "@capacitor/preferences": "^6.0.1",
     "@capacitor/status-bar": "6.0.0",
     "@ionic/react": "^8.0.0",
     "@ionic/react-router": "^8.0.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,7 +35,6 @@ import CheckQRCodeScreen from "./onboarding/CheckQRCodeScreen/CheckQRCodeScreen.
 import { LoginOkScreen } from "./onboarding/LoginOk/LoginOkScreen.jsx";
 import { MainScreen } from "./onboarding/Home/MainScreen.jsx";
 import { useUser } from "./util/hooks.js";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 setupIonicReact();
 
@@ -44,34 +43,31 @@ const App = () => {
   if (user === undefined) {
     return <p>Loading...</p>;
   }
-  const queryClient = new QueryClient();
   return (
-    <QueryClientProvider client={queryClient}>
-      <IonApp>
-        <IonReactRouter>
-          <IonRouterOutlet>
-            <Route exact path="/onboarding">
-              {
-                /* If the user is logged in, redirect them to the app */
-                user !== null ? <Redirect to="/app" /> : <OnboardingScreen />
-              }
-            </Route>
-            <Route path="/check-creds">
-              <CheckQRCodeScreen />
-            </Route>
-            <Route path="/login-ok">
-              <LoginOkScreen />
-            </Route>
-            <Route path="/app">
-              <MainScreen />
-            </Route>
-            <Route exact path="/">
-              <Redirect to="/onboarding" />
-            </Route>
-          </IonRouterOutlet>
-        </IonReactRouter>
-      </IonApp>
-    </QueryClientProvider>
+    <IonApp>
+      <IonReactRouter>
+        <IonRouterOutlet>
+          <Route exact path="/onboarding">
+            {
+              /* If the user is logged in, redirect them to the app */
+              user !== null ? <Redirect to="/app" /> : <OnboardingScreen />
+            }
+          </Route>
+          <Route path="/check-creds">
+            <CheckQRCodeScreen />
+          </Route>
+          <Route path="/login-ok">
+            <LoginOkScreen />
+          </Route>
+          <Route path="/app">
+            <MainScreen />
+          </Route>
+          <Route exact path="/">
+            <Redirect to="/onboarding" />
+          </Route>
+        </IonRouterOutlet>
+      </IonReactRouter>
+    </IonApp>
   );
 };
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,13 +34,14 @@ import React from "react";
 import CheckQRCodeScreen from "./onboarding/CheckQRCodeScreen/CheckQRCodeScreen.jsx";
 import { LoginOkScreen } from "./onboarding/LoginOk/LoginOkScreen.jsx";
 import { MainScreen } from "./onboarding/Home/MainScreen.jsx";
-import { useUser } from "./util/hooks.js";
+import { useSkipOnboarding, useUser } from "./util/hooks.js";
 
 setupIonicReact();
 
 const App = () => {
+  const { skipOnboarding, status } = useSkipOnboarding();
   const user = useUser();
-  if (user === undefined) {
+  if (user === undefined || status === "loading") {
     return <p>Loading...</p>;
   }
   return (
@@ -50,7 +51,11 @@ const App = () => {
           <Route exact path="/onboarding">
             {
               /* If the user is logged in, redirect them to the app */
-              user !== null ? <Redirect to="/app" /> : <OnboardingScreen />
+              user !== null || skipOnboarding ? (
+                <Redirect to="/app" />
+              ) : (
+                <OnboardingScreen />
+              )
             }
           </Route>
           <Route path="/check-creds">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,47 +31,46 @@ import { IonReactRouter } from "@ionic/react-router";
 import { Redirect, Route } from "react-router";
 import OnboardingScreen from "./onboarding/OnboardingScreen/OnboardingScreen.jsx";
 import React from "react";
-import { AppContext } from "./util/context.js";
 import CheckQRCodeScreen from "./onboarding/CheckQRCodeScreen/CheckQRCodeScreen.jsx";
 import { LoginOkScreen } from "./onboarding/LoginOk/LoginOkScreen.jsx";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MainScreen } from "./onboarding/Home/MainScreen.jsx";
+import { useUser } from "./util/hooks.js";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 setupIonicReact();
-const queryClient = new QueryClient();
 
 const App = () => {
-  const [userInfo, setUserInfo] = React.useState({
-    name: undefined,
-    token: undefined,
-    instance: null,
-    axiosClient: null,
-  });
+  const user = useUser();
+  if (user === undefined) {
+    return <p>Loading...</p>;
+  }
+  const queryClient = new QueryClient();
   return (
     <QueryClientProvider client={queryClient}>
-      <AppContext.Provider value={{ userInfo, setUserInfo }}>
-        <IonApp>
-          <IonReactRouter>
-            <IonRouterOutlet>
-              <Route exact path="/onboarding">
-                <OnboardingScreen />
-              </Route>
-              <Route path="/check-creds">
-                <CheckQRCodeScreen />
-              </Route>
-              <Route path="/login-ok">
-                <LoginOkScreen />
-              </Route>
-              <Route path="/app">
-                <MainScreen />
-              </Route>
-              <Route exact path="/">
-                <Redirect to="/onboarding" />
-              </Route>
-            </IonRouterOutlet>
-          </IonReactRouter>
-        </IonApp>
-      </AppContext.Provider>
+      <IonApp>
+        <IonReactRouter>
+          <IonRouterOutlet>
+            <Route exact path="/onboarding">
+              {
+                /* If the user is logged in, redirect them to the app */
+                user !== null ? <Redirect to="/app" /> : <OnboardingScreen />
+              }
+            </Route>
+            <Route path="/check-creds">
+              <CheckQRCodeScreen />
+            </Route>
+            <Route path="/login-ok">
+              <LoginOkScreen />
+            </Route>
+            <Route path="/app">
+              <MainScreen />
+            </Route>
+            <Route exact path="/">
+              <Redirect to="/onboarding" />
+            </Route>
+          </IonRouterOutlet>
+        </IonReactRouter>
+      </IonApp>
     </QueryClientProvider>
   );
 };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,9 +39,9 @@ import { useSkipOnboarding, useUser } from "./util/hooks.js";
 setupIonicReact();
 
 const App = () => {
-  const { skipOnboarding, status } = useSkipOnboarding();
-  const user = useUser();
-  if (user === undefined || status === "loading") {
+  const { skipOnboarding, status: skipOnboardingStatus } = useSkipOnboarding();
+  const { user, status: userStatus } = useUser();
+  if (userStatus === "pending" || skipOnboardingStatus === "pending") {
     return <p>Loading...</p>;
   }
   return (

--- a/src/config.js
+++ b/src/config.js
@@ -2,7 +2,7 @@ const mode = import.meta.env.MODE;
 
 export default {
   SKIP_ONBOARDING:
-    mode === "development" && import.meta.env.VITE_SKIP_ONBOARDING,
+    mode === "development" && import.meta.env.VITE_SKIP_ONBOARDING === "true",
   TOKEN: import.meta.env.VITE_SKYPORTAL_TOKEN,
   INSTANCE_URL: import.meta.env.VITE_INSTANCE_URL,
   INSTANCE_NAME: import.meta.env.VITE_INSTANCE_NAME,

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,9 @@
+const mode = import.meta.env.MODE;
+
+export default {
+  SKIP_ONBOARDING:
+    mode === "development" && import.meta.env.VITE_SKIP_ONBOARDING,
+  TOKEN: import.meta.env.VITE_SKYPORTAL_TOKEN,
+  INSTANCE_URL: import.meta.env.VITE_INSTANCE_URL,
+  INSTANCE_NAME: import.meta.env.VITE_INSTANCE_NAME,
+};

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" /> interface ImportMeta { readonly env: ImportMetaEnv }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,17 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const container = document.getElementById("root");
 // @ts-ignore
 const root = createRoot(container);
+const queryClient = new QueryClient();
 
 root.render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,11 +1,13 @@
-import React from 'react';
-import { createRoot } from 'react-dom/client';
-import App from './App';
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
 
-const container = document.getElementById('root');
+const container = document.getElementById("root");
+// @ts-ignore
 const root = createRoot(container);
+
 root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/onboarding/CheckQRCodeScreen/CheckQRCodeScreen.jsx
+++ b/src/onboarding/CheckQRCodeScreen/CheckQRCodeScreen.jsx
@@ -31,7 +31,7 @@ export const CheckQRCodeScreen = () => {
   });
   useEffect(() => {
     // @ts-ignore
-    loginMutation.mutate({ token, instance: instance.url });
+    loginMutation.mutate({ token, instanceUrl: instance.url });
   }, []);
 
   return (

--- a/src/onboarding/LoginOk/LoginOkScreen.jsx
+++ b/src/onboarding/LoginOk/LoginOkScreen.jsx
@@ -1,17 +1,17 @@
 import { IonContent, IonIcon, IonPage } from "@ionic/react";
 import "./LoginOkScreen.scss";
 import { checkmarkCircleSharp } from "ionicons/icons";
-import { useContext, useEffect } from "react";
-import { AppContext } from "../../util/context.js";
+import { useEffect } from "react";
 import { useHistory } from "react-router";
+import { useUser } from "../../util/hooks.js";
 
 export const LoginOkScreen = () => {
-  const { userInfo } = useContext(AppContext);
+  const user = useUser();
   const history = useHistory();
 
   useEffect(() => {
     setTimeout(() => {
-      history.push("/app");
+      history.replace("/app");
     }, 2000);
   }, []);
 
@@ -26,7 +26,7 @@ export const LoginOkScreen = () => {
           />
           <div className="text">
             <p className="success-hint">Connected successfully</p>
-            <p className="welcome-hint">Welcome back {userInfo.name}! 😄</p>
+            <p className="welcome-hint">Welcome back {user?.first_name}! 😄</p>
           </div>
         </div>
       </IonContent>

--- a/src/onboarding/LoginOk/LoginOkScreen.jsx
+++ b/src/onboarding/LoginOk/LoginOkScreen.jsx
@@ -6,14 +6,19 @@ import { useHistory } from "react-router";
 import { useUser } from "../../util/hooks.js";
 
 export const LoginOkScreen = () => {
-  const user = useUser();
   const history = useHistory();
+  const { user } = useUser();
 
   useEffect(() => {
-    setTimeout(() => {
-      history.replace("/app");
-    }, 2000);
-  }, []);
+    /** @type {any} */
+    let timer;
+    if (user) {
+      timer = setTimeout(() => {
+        history.replace("/app");
+      }, 2000);
+    }
+    return () => clearTimeout(timer);
+  }, [user]);
 
   return (
     <IonPage>

--- a/src/onboarding/OnboardingLower/OnboardingLower.jsx
+++ b/src/onboarding/OnboardingLower/OnboardingLower.jsx
@@ -1,16 +1,24 @@
 import { IonButton, IonIcon, IonSelect, IonSelectOption } from "@ionic/react";
 import "./OnboardingLower.scss";
-import { INSTANCES } from "../../util/constants.js";
-import { useContext } from "react";
+import { INSTANCES, QUERY_PARAMS } from "../../util/constants.js";
+import { useState } from "react";
 import { qrCode } from "ionicons/icons";
-import { AppContext } from "../../util/context.js";
 import { CapacitorBarcodeScanner } from "@capacitor/barcode-scanner";
 import { Html5QrcodeSupportedFormats } from "html5-qrcode";
 import { useHistory } from "react-router";
 
+/**
+ * The lower part of the onboarding screen
+ * @param {Object} props
+ * @param {string} props.page - The current page of the onboarding screen
+ * @param {Function} props.setPage - The function to set the current page of the onboarding screen
+ * @returns {JSX.Element}
+ * @constructor
+ */
 const OnboardingLower = ({ page, setPage }) => {
   const history = useHistory();
-  const { userInfo, setUserInfo } = useContext(AppContext);
+  const [instance, setInstance] = useState(null);
+  // @ts-ignore
   let token = import.meta.env.VITE_ICARE_TOKEN ?? "test";
   async function handleScanQRCode() {
     try {
@@ -21,7 +29,11 @@ const OnboardingLower = ({ page, setPage }) => {
     } catch (error) {
       console.error(error);
     }
-    history.push(`/check-creds?token=${token}`);
+    history.push(
+      encodeURI(
+        `/check-creds?${QUERY_PARAMS.TOKEN}=${token}&${QUERY_PARAMS.INSTANCE}=${JSON.stringify(instance)}`,
+      ),
+    );
   }
 
   if (page === "welcome")
@@ -45,9 +57,7 @@ const OnboardingLower = ({ page, setPage }) => {
             class="select"
             label={"Instance"}
             placeholder="Select an instance"
-            onIonChange={(e) =>
-              setUserInfo({ ...userInfo, instance: e.detail.value })
-            }
+            onIonChange={(e) => setInstance(e.detail.value)}
           >
             {INSTANCES.map((instance) => (
               <IonSelectOption key={instance.name} value={instance}>
@@ -60,13 +70,13 @@ const OnboardingLower = ({ page, setPage }) => {
           <IonButton
             onClick={() => handleScanQRCode()}
             shape="round"
-            disabled={userInfo.instance === null}
+            disabled={instance === null}
             strong
           >
             <IonIcon slot="start" icon={qrCode}></IonIcon>
             Scan QR code
           </IonButton>
-          <IonButton shape="round" disabled={userInfo.instance === null} strong>
+          <IonButton shape="round" disabled={instance === null} strong>
             Log in with token
           </IonButton>
         </div>

--- a/src/onboarding/auth.js
+++ b/src/onboarding/auth.js
@@ -1,12 +1,41 @@
-import { CapacitorHttp } from "@capacitor/core";
+import { Capacitor, CapacitorHttp } from "@capacitor/core";
 import mockUser from "../../mock/user.json";
 
-export const checkToken = async (token, instance, platform) => {
-  if (platform === "web") {
-    return mockUser;
+/**
+ * @template T
+ * @typedef {Object} SkyPortalResponse
+ * @property {string} status - The status of the response
+ * @property {T} data - The data from the response
+ */
+
+/**
+ * @typedef {Object} User
+ * @property {string} username - The username of the user
+ * @property {string} first_name - The first name of the user
+ * @property {string} last_name - The last name of the user
+ * @property {string|null} contact_email - The email of the user
+ * @property {string|null} contact_phone - The phone number of the user
+ */
+
+/**
+ * @typedef {Object} UserInfo
+ * @property {string} token - The token of the user
+ * @property {import("../util/constants.js").SkyPortalInstance} instance - The instance of the user
+ */
+
+/**
+ * Check the token and fetch the user from the API
+ * @param {Object} params
+ * @param {string} params.token - The token to use to fetch the user
+ * @param {string} params.instance - The instance to use to fetch the user
+ * @returns {Promise<User>} - The user from the API
+ */
+export const checkTokenAndFetchUser = async ({ token, instance }) => {
+  if (Capacitor.getPlatform() === "web") {
+    return mockUser.data;
   }
   const response = await CapacitorHttp.get({
-    url: `${instance.url}/api/internal/profile`,
+    url: `${instance}/api/internal/profile`,
     headers: {
       Authorization: `token ${token}`,
     },

--- a/src/onboarding/auth.js
+++ b/src/onboarding/auth.js
@@ -27,15 +27,15 @@ import mockUser from "../../mock/user.json";
  * Check the token and fetch the user from the API
  * @param {Object} params
  * @param {string} params.token - The token to use to fetch the user
- * @param {string} params.instance - The instance to use to fetch the user
+ * @param {string} params.instanceUrl - The url of the instance to use to fetch the user
  * @returns {Promise<User>} - The user from the API
  */
-export const checkTokenAndFetchUser = async ({ token, instance }) => {
+export const checkTokenAndFetchUser = async ({ token, instanceUrl }) => {
   if (Capacitor.getPlatform() === "web") {
     return mockUser.data;
   }
   const response = await CapacitorHttp.get({
-    url: `${instance}/api/internal/profile`,
+    url: `${instanceUrl}/api/internal/profile`,
     headers: {
       Authorization: `token ${token}`,
     },

--- a/src/scanning/MainScanningScreen/MainScanningScreen.jsx
+++ b/src/scanning/MainScanningScreen/MainScanningScreen.jsx
@@ -1,26 +1,16 @@
 import "./MainScanningScreen.scss";
 import { IonButton, IonContent, IonPage } from "@ionic/react";
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
-import {
-  getThumbnailImageUrl,
-  searchCandidates,
-  THUMBNAIL_TYPES,
-} from "../scanning.js";
+import { getThumbnailImageUrl, THUMBNAIL_TYPES } from "../scanning.js";
 import { Thumbnail } from "../Thumbnail/Thumbnail.jsx";
 import { CandidateAnnotations } from "../CandidateAnnotations/CandidateAnnotations.jsx";
+import { useSearchCandidates } from "../../util/hooks.js";
 
 export const MainScanningScreen = () => {
   const [currentCandidateIndex, setCurrentCandidateIndex] = useState(0);
-  const {
-    data: candidates,
-    status,
-    error,
-  } = useQuery({
-    queryKey: ["candidates"],
-    queryFn: () => searchCandidates(),
-  });
-  if (status === "pending") {
+  const { candidates, status, error } = useSearchCandidates();
+
+  if (!candidates || status === "pending") {
     return <p>Loading...</p>;
   }
   if (status === "error") {

--- a/src/scanning/MainScanningScreen/MainScanningScreen.jsx
+++ b/src/scanning/MainScanningScreen/MainScanningScreen.jsx
@@ -1,19 +1,16 @@
 import "./MainScanningScreen.scss";
 import { IonButton, IonContent, IonPage } from "@ionic/react";
-import { useContext, useState } from "react";
-import { AppContext } from "../../util/context.js";
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   getThumbnailImageUrl,
   searchCandidates,
   THUMBNAIL_TYPES,
 } from "../scanning.js";
-import { Capacitor } from "@capacitor/core";
 import { Thumbnail } from "../Thumbnail/Thumbnail.jsx";
 import { CandidateAnnotations } from "../CandidateAnnotations/CandidateAnnotations.jsx";
 
 export const MainScanningScreen = () => {
-  const { userInfo } = useContext(AppContext);
   const [currentCandidateIndex, setCurrentCandidateIndex] = useState(0);
   const {
     data: candidates,
@@ -21,12 +18,7 @@ export const MainScanningScreen = () => {
     error,
   } = useQuery({
     queryKey: ["candidates"],
-    queryFn: () =>
-      searchCandidates({
-        token: userInfo.token,
-        instanceUrl: userInfo.instance.url,
-        platform: Capacitor.getPlatform(),
-      }),
+    queryFn: () => searchCandidates(),
   });
   if (status === "pending") {
     return <p>Loading...</p>;

--- a/src/scanning/ScanningOptionsScreen/ScanningOptionsScreen.jsx
+++ b/src/scanning/ScanningOptionsScreen/ScanningOptionsScreen.jsx
@@ -15,16 +15,13 @@ import {
   IonToolbar,
 } from "@ionic/react";
 import { useQuery } from "@tanstack/react-query";
-import { useContext, useState } from "react";
+import { useState } from "react";
 import { searchCandidates } from "../scanning.js";
-import { AppContext } from "../../util/context.js";
-import { Capacitor } from "@capacitor/core";
 import { useForm } from "react-hook-form";
 import { useHistory } from "react-router";
 
 export const ScanningOptionsScreen = () => {
   const history = useHistory();
-  const { userInfo } = useContext(AppContext);
   const [currentCandidateIndex, setCurrentCandidateIndex] = useState(0);
   const {
     data: candidates,
@@ -32,12 +29,7 @@ export const ScanningOptionsScreen = () => {
     error,
   } = useQuery({
     queryKey: ["candidates"],
-    queryFn: () =>
-      searchCandidates({
-        token: userInfo.token,
-        instanceUrl: userInfo.instance.url,
-        platform: Capacitor.getPlatform(),
-      }),
+    queryFn: () => searchCandidates(),
   });
   const {
     register,
@@ -46,6 +38,9 @@ export const ScanningOptionsScreen = () => {
     reset,
     getValues,
   } = useForm();
+  /**
+   * @param {Object} data
+   */
   const onSubmit = (data) => {
     console.log(data);
     history.push("/app/scanning/main");

--- a/src/scanning/ScanningOptionsScreen/ScanningOptionsScreen.jsx
+++ b/src/scanning/ScanningOptionsScreen/ScanningOptionsScreen.jsx
@@ -14,23 +14,15 @@ import {
   IonToggle,
   IonToolbar,
 } from "@ionic/react";
-import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
-import { searchCandidates } from "../scanning.js";
 import { useForm } from "react-hook-form";
 import { useHistory } from "react-router";
+import { useSearchCandidates } from "../../util/hooks.js";
 
 export const ScanningOptionsScreen = () => {
   const history = useHistory();
   const [currentCandidateIndex, setCurrentCandidateIndex] = useState(0);
-  const {
-    data: candidates,
-    status,
-    error,
-  } = useQuery({
-    queryKey: ["candidates"],
-    queryFn: () => searchCandidates(),
-  });
+  const { candidates, status, error } = useSearchCandidates();
   const {
     register,
     handleSubmit,

--- a/src/scanning/scanning.js
+++ b/src/scanning/scanning.js
@@ -1,7 +1,18 @@
 import mockCandidates from "../../mock/candidates.json";
 import { Capacitor, CapacitorHttp } from "@capacitor/core";
-import { getPreference } from "../util/preferences.js";
-import { PREFERENCES } from "../util/constants.js";
+
+/**
+ * @typedef {Object} CandidateThumbnail
+ * @property {string} type - Thumbnail type
+ * @property {string} public_url - URL of the thumbnail
+ */
+
+/**
+ * @typedef {Object} Candidate
+ * @property {CandidateThumbnail[]} thumbnails - Thumbnails of the candidate
+ * @property {number} ra - Right ascension
+ * @property {number} dec - Declination
+ */
 
 export const THUMBNAIL_TYPES = {
   new: "new",
@@ -71,15 +82,21 @@ export const getThumbnailHeader = (type) => {
   }
 };
 
-export async function searchCandidates() {
+/**
+ * Returns the candidates from the API
+ * @param {Object} params
+ * @param {string} params.instanceUrl - The URL of the instance
+ * @param {string} params.token - The token to use to fetch the candidates
+ * @returns {Promise<Candidate[]>}
+ */
+export async function searchCandidates({ instanceUrl, token }) {
   if (Capacitor.getPlatform() === "web") {
-    return mockCandidates;
+    return mockCandidates.data.candidates;
   }
-  const userInfo = await getPreference({ key: PREFERENCES.USER_INFO });
   let response = await CapacitorHttp.get({
-    url: `${userInfo.instance.url}/api/candidates`,
+    url: `${instanceUrl}/api/candidates`,
     headers: {
-      Authorization: `token ${userInfo.token}`,
+      Authorization: `token ${token}`,
     },
     params: {
       pageNumber: "1",
@@ -92,18 +109,6 @@ export async function searchCandidates() {
   });
   return response.data.data.candidates;
 }
-
-/**
- * @typedef {Object} CandidateThumbnail
- * @property {string} type - Thumbnail type
- * @property {string} public_url - URL of the thumbnail
- */
-
-/**
- * @typedef {Object} Candidate
- * @property {CandidateThumbnail[]} thumbnails - Thumbnails of the candidate
- *
- */
 
 /**
  * Get the URL of the thumbnail image

--- a/src/sources/SourceList/SourceListScreen.jsx
+++ b/src/sources/SourceList/SourceListScreen.jsx
@@ -6,15 +6,12 @@ import {
   IonTitle,
   IonToolbar,
 } from "@ionic/react";
-import { useContext, useState } from "react";
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { fetchSources } from "../sources.js";
-import { AppContext } from "../../util/context.js";
-import { Capacitor } from "@capacitor/core";
 import { SourceListItem } from "../SourceListItem/SourceListItem.jsx";
 
 export const SourceListScreen = () => {
-  const { userInfo } = useContext(AppContext);
   const [page, setPage] = useState(1);
   const [numPerPage, setNumPerPage] = useState(10);
   const {
@@ -22,15 +19,8 @@ export const SourceListScreen = () => {
     status,
     error,
   } = useQuery({
-    queryKey: ["sources", page, numPerPage, userInfo.token],
-    queryFn: () =>
-      fetchSources(
-        page,
-        numPerPage,
-        userInfo.instance.url,
-        userInfo.token,
-        Capacitor.getPlatform(),
-      ),
+    queryKey: ["sources", page, numPerPage],
+    queryFn: () => fetchSources(page, numPerPage),
   });
   return (
     <IonPage>
@@ -41,7 +31,7 @@ export const SourceListScreen = () => {
           </IonToolbar>
         </IonHeader>
         <div className="source-list">
-          {status === "loading" && <p>Loading...</p>}
+          {status === "pending" && <p>Loading...</p>}
           {status === "error" && <p>Error: {error.message} </p>}
           {status === "success" &&
             sources.map((source) => (

--- a/src/sources/SourceList/SourceListScreen.jsx
+++ b/src/sources/SourceList/SourceListScreen.jsx
@@ -7,21 +7,16 @@ import {
   IonToolbar,
 } from "@ionic/react";
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { fetchSources } from "../sources.js";
 import { SourceListItem } from "../SourceListItem/SourceListItem.jsx";
+import { useFetchSources } from "../../util/hooks.js";
 
 export const SourceListScreen = () => {
   const [page, setPage] = useState(1);
   const [numPerPage, setNumPerPage] = useState(10);
-  const {
-    data: sources,
-    status,
-    error,
-  } = useQuery({
-    queryKey: ["sources", page, numPerPage],
-    queryFn: () => fetchSources(page, numPerPage),
-  });
+  const { sources, status, error } = useFetchSources({ page, numPerPage });
+  if (!sources) {
+    return <p>Loading...</p>;
+  }
   return (
     <IonPage>
       <IonContent>

--- a/src/sources/sources.js
+++ b/src/sources/sources.js
@@ -1,24 +1,28 @@
 import { Capacitor, CapacitorHttp } from "@capacitor/core";
 import mockSources from "../../mock/sources.json";
-import { getPreference } from "../util/preferences.js";
-import { PREFERENCES } from "../util/constants.js";
+
+/**
+ * @typedef {Object} Source
+ * @property {string} id - Source ID
+ * @property {number} ra - Right ascension
+ * @property {number} dec - Declination
+ */
 
 /**
  * Fetch sources from the API
- * @param {number} page - page number
- * @param {number} numPerPage - number of sources per page
- * @returns {Promise<any[]>}
+ * @param {Object} props
+ * @param {string} props.instanceUrl - URL of the SkyPortal instance
+ * @param {string} props.token - User token
+ * @param {number} props.page - page number
+ * @param {number} props.numPerPage - number of sources per page
+ * @returns {Promise<import("../sources/sources.js").Source[]>}
  */
-export async function fetchSources(page, numPerPage) {
+export async function fetchSources({ instanceUrl, token, page, numPerPage }) {
   if (Capacitor.getPlatform() === "web") {
     return mockSources.data.sources;
   }
-  // @ts-ignore
-  const { instance, token } = await getPreference({
-    key: PREFERENCES.USER_INFO,
-  });
   let response = await CapacitorHttp.get({
-    url: `${instance.url}/api/sources`,
+    url: `${instanceUrl}/api/sources`,
     headers: {
       Authorization: `token ${token}`,
     },

--- a/src/sources/sources.js
+++ b/src/sources/sources.js
@@ -1,27 +1,24 @@
-import { CapacitorHttp } from "@capacitor/core";
+import { Capacitor, CapacitorHttp } from "@capacitor/core";
 import mockSources from "../../mock/sources.json";
+import { getPreference } from "../util/preferences.js";
+import { PREFERENCES } from "../util/constants.js";
 
 /**
  * Fetch sources from the API
  * @param {number} page - page number
  * @param {number} numPerPage - number of sources per page
- * @param {string} instanceUrl - SkyPortal instance URL
- * @param {string} token - SkyPortal token
- * @param {string} platform - Platform
  * @returns {Promise<any[]>}
  */
-export async function fetchSources(
-  page,
-  numPerPage,
-  instanceUrl,
-  token,
-  platform,
-) {
-  if (platform === "web") {
-    return mockSources;
+export async function fetchSources(page, numPerPage) {
+  if (Capacitor.getPlatform() === "web") {
+    return mockSources.data.sources;
   }
+  // @ts-ignore
+  const { instance, token } = await getPreference({
+    key: PREFERENCES.USER_INFO,
+  });
   let response = await CapacitorHttp.get({
-    url: `${instanceUrl}/api/sources`,
+    url: `${instance.url}/api/sources`,
     headers: {
       Authorization: `token ${token}`,
     },

--- a/src/util/constants.js
+++ b/src/util/constants.js
@@ -30,4 +30,5 @@ export const QUERY_KEYS = {
   CANDIDATES: "candidates",
   SOURCES: "sources",
   USER: "user",
+  USER_INFO: "userInfo",
 };

--- a/src/util/constants.js
+++ b/src/util/constants.js
@@ -12,5 +12,16 @@
 export const INSTANCES = [
   { name: "ICARE", url: "https://skyportal-icare.ijclab.in2p3.fr" },
   { name: "FRITZ", url: "https://fritz.science" },
-  { name: "FRITZ preview", url: "https://preview.fritz.science"}
+  { name: "FRITZ preview", url: "https://preview.fritz.science" },
 ];
+
+export const PREFERENCES = {
+  TOKEN: "token",
+  USER: "user",
+  USER_INFO: "userInfo",
+};
+
+export const QUERY_PARAMS = {
+  TOKEN: "token",
+  INSTANCE: "instance",
+};

--- a/src/util/constants.js
+++ b/src/util/constants.js
@@ -25,3 +25,9 @@ export const QUERY_PARAMS = {
   TOKEN: "token",
   INSTANCE: "instance",
 };
+
+export const QUERY_KEYS = {
+  CANDIDATES: "candidates",
+  SOURCES: "sources",
+  USER: "user",
+};

--- a/src/util/context.js
+++ b/src/util/context.js
@@ -1,3 +1,0 @@
-import React from "react";
-
-export const AppContext = React.createContext({});

--- a/src/util/hooks.js
+++ b/src/util/hooks.js
@@ -1,36 +1,103 @@
 import { useQuery } from "@tanstack/react-query";
-import { PREFERENCES } from "./constants.js";
+import { PREFERENCES, QUERY_KEYS } from "./constants.js";
+import { searchCandidates } from "../scanning/scanning.js";
+import { fetchSources } from "../sources/sources.js";
 import { getPreference } from "./preferences.js";
+
+/**
+ * @typedef {"success" | "error" | "pending"} QueryStatus
+ */
 
 /**
  * @template T
  * Custom hook to get a preference from the preferences
  * @param {string} key
- * @returns {T|undefined}
+ * @returns {{data:T|undefined, status: QueryStatus, error: any|undefined}}
  */
 const usePreference = (key) => {
-  const { data: value, status } = useQuery({
+  return useQuery({
     queryKey: [key],
     queryFn: () => getPreference({ key }),
   });
-  if (status === "pending" || status === "error") {
-    return undefined;
-  }
-  return value;
 };
 
 /**
  * Custom hook to get the user from the preferences
- * @returns {import("../onboarding/auth.js").User|undefined}
+ * @returns {{user: import("../onboarding/auth.js").User|undefined, status: QueryStatus, error: any|undefined}}
  */
 export const useUser = () => {
-  return usePreference(PREFERENCES.USER);
+  const res = usePreference(PREFERENCES.USER);
+  return {
+    user: res.data,
+    status: res.status,
+    error: res.error,
+  };
 };
 
 /**
  * Custom hook to get the user info from the preferences
- * @returns {{token: string, instance: import("./constants.js").SkyPortalInstance}|undefined}
+ * @returns {{userInfo: import("../onboarding/auth.js").UserInfo|undefined, status: QueryStatus, error: any|undefined}}
  */
 export const useUserInfo = () => {
-  return usePreference(PREFERENCES.USER_INFO);
+  const res = usePreference(PREFERENCES.USER_INFO);
+  return {
+    userInfo: res.data,
+    status: res.status,
+    error: res.error,
+  };
+};
+
+/**
+ * @returns {{candidates: import("../scanning/scanning.js").Candidate[]|undefined, status: QueryStatus, error: any}}
+ */
+export const useSearchCandidates = () => {
+  const { userInfo } = useUserInfo();
+  const {
+    data: candidates,
+    status,
+    error,
+  } = useQuery({
+    queryKey: [QUERY_KEYS.CANDIDATES],
+    queryFn: () =>
+      searchCandidates({
+        instanceUrl: userInfo?.instance.url ?? "",
+        token: userInfo?.token ?? "",
+      }),
+    enabled: !!userInfo,
+  });
+  return {
+    candidates,
+    status,
+    error,
+  };
+};
+
+/**
+ * @param {Object} props
+ * @param {number} props.page
+ * @param {number} props.numPerPage
+ * @returns {{sources: import("../sources/sources.js").Source[]|undefined, status: QueryStatus, error: any|undefined}}
+ */
+export const useFetchSources = ({ page, numPerPage }) => {
+  const { userInfo } = useUserInfo();
+  const {
+    data: sources,
+    status,
+    error,
+  } = useQuery({
+    queryKey: [QUERY_KEYS.SOURCES, page, numPerPage],
+    queryFn: () =>
+      fetchSources({
+        instanceUrl: userInfo?.instance.url ?? "",
+        token: userInfo?.token ?? "",
+        page,
+        numPerPage,
+      }),
+    enabled: !!userInfo,
+  });
+  return {
+    sources,
+    status,
+    error,
+  };
 };

--- a/src/util/hooks.js
+++ b/src/util/hooks.js
@@ -1,0 +1,36 @@
+import { useQuery } from "@tanstack/react-query";
+import { PREFERENCES } from "./constants.js";
+import { getPreference } from "./preferences.js";
+
+/**
+ * @template T
+ * Custom hook to get a preference from the preferences
+ * @param {string} key
+ * @returns {T|undefined}
+ */
+const usePreference = (key) => {
+  const { data: value, status } = useQuery({
+    queryKey: [key],
+    queryFn: () => getPreference({ key }),
+  });
+  if (status === "pending" || status === "error") {
+    return undefined;
+  }
+  return value;
+};
+
+/**
+ * Custom hook to get the user from the preferences
+ * @returns {import("../onboarding/auth.js").User|undefined}
+ */
+export const useUser = () => {
+  return usePreference(PREFERENCES.USER);
+};
+
+/**
+ * Custom hook to get the user info from the preferences
+ * @returns {{token: string, instance: import("./constants.js").SkyPortalInstance}|undefined}
+ */
+export const useUserInfo = () => {
+  return usePreference(PREFERENCES.USER_INFO);
+};

--- a/src/util/preferences.js
+++ b/src/util/preferences.js
@@ -1,0 +1,40 @@
+import { Preferences } from "@capacitor/preferences";
+
+/**
+ * @typedef {Object} SetOptions
+ * @property {string} key - The key to associate with the value being set in preferences.
+ * @property {any} value - The value to set in preferences with the associated key.
+ */
+
+/**
+ * @typedef {Object} GetOptions
+ * @property {string} key - The key to retrieve the value from preferences.
+ */
+
+/**
+ * @typedef {Object} GetResult
+ * @property {string|null} value - The value from preferences associated with the given key.
+ * If a value was not previously set or was removed, value will be `null`
+ */
+
+/**
+ * Set a preference in the app
+ * @param {SetOptions} options - The options to set the preference.
+ * @returns {Promise<void>}
+ */
+export async function setPreference({ key, value }) {
+  return await Preferences.set({ key, value: JSON.stringify(value) });
+}
+
+/**
+ * Get a preference in the app
+ * @param {GetOptions} options - The options to get the preference.
+ * @returns {Promise<any>}
+ */
+export async function getPreference({ key }) {
+  const pref = await Preferences.get({ key });
+  if (pref.value !== null) {
+    return JSON.parse(pref.value);
+  }
+  return null;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "checkJs": true
   },
-  "include": ["src"],
+  "include": ["src"]
 }


### PR DESCRIPTION
* Persist authentication
  * Install @capacitor/preferences for native device preferences access
  * New preferences.js file with `setPreference` and `getPreference` functions
  * New hooks.js file with `useUser` and `useUserInfo` hooks to get data from preferences
  * Add redirection to "/app" for "/onboarding" if the user is logged in
  * Remove `userInfo` global state
  * Remove `AppContext`
  * Rename `checkToken` into `checkTokenAndFetchUser` in auth.js
  * Remove platform, token and url from function arguments and get them directly from Capacitor
  * Use React query mutation to log user in, in CheckQRCodeScreen.jsx
  * Add constants for preferences
  * Use `history.replace` in LoginOkScreen.jsx
  * Activate `checkJs` in tsconfig.json and fix typing
* New custom hooks
  * Put QueryClientProvider in main.jsx
  * New constant `QUERY_KEYS`
  * New `useSearchCandidates` and `useFetchSources` hooks
* Skip onboarding in dev mode
  * New config.js file
  * New env.d.ts file to fix tslint for vite env
  * New `useSkipOnboarding` hook to automatically skip onboarding if the configuration allows it
  * Use `useSkipOnboarding` hook in App.jsx