### PR TITLE
Fetch candidates continuously

### DIFF
--- a/src/common/hooks.js
+++ b/src/common/hooks.js
@@ -4,17 +4,16 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import { QUERY_KEYS } from "./constants.js";
-import {
-  fetchGroups,
-  fetchSourcePhotometry,
-  searchCandidates,
-} from "../scanning/scanning.js";
 import { fetchSources } from "../sources/sources.js";
 import { getPreference, setPreference } from "./preferences.js";
 import config from "../config.js";
 import { checkTokenAndFetchUser } from "../onboarding/auth.js";
 import { useState } from "react";
 import { fetchConfig } from "./requests.js";
+import {
+  fetchGroups,
+  fetchSourcePhotometry,
+} from "../scanning/scanningRequests.js";
 
 /**
  * @typedef {"success" | "error" | "pending"} QueryStatus
@@ -56,55 +55,6 @@ export const useUserInfo = () => {
     userInfo: res.data,
     status: res.status,
     error: res.error,
-  };
-};
-
-/**
- * @param {Object} props
- * @param {string} props.startDate
- * @param {string|null} [props.endDate=null]
- * @param {import("../common/constants").SavedStatus} props.savedStatus
- * @param {string} props.groupIDs
- * @returns {{candidates: import("../scanning/scanning.js").Candidate[]|undefined, status: QueryStatus, error: any}}
- */
-export const useSearchCandidates = ({
-  startDate,
-  endDate = null,
-  savedStatus,
-  groupIDs,
-}) => {
-  const { userInfo } = useUserInfo();
-  const {
-    /** @type {import("../scanning/scanning.js").Candidate[]} */ data: candidates,
-    status,
-    error,
-  } = useQuery({
-    queryKey: [
-      QUERY_KEYS.CANDIDATES,
-      startDate,
-      endDate,
-      savedStatus,
-      groupIDs,
-    ],
-    queryFn: async () => {
-      if (!startDate || !endDate || !savedStatus || !groupIDs) {
-        throw new Error("Missing parameters");
-      }
-      return await searchCandidates({
-        instanceUrl: userInfo?.instance.url ?? "",
-        token: userInfo?.token ?? "",
-        startDate,
-        endDate,
-        savedStatus,
-        groupIDs,
-      });
-    },
-    enabled: !!userInfo && !!startDate,
-  });
-  return {
-    candidates,
-    status,
-    error,
   };
 };
 
@@ -214,12 +164,12 @@ export const useAppStart = () => {
 };
 
 /**
- * @returns {{userAccessibleGroups: import("../scanning/scanning.js").Group[]|undefined, status: QueryStatus, error: any|undefined}}
+ * @returns {{userAccessibleGroups: import("../scanning/scanningLib.js").Group[]|undefined, status: QueryStatus, error: any|undefined}}
  */
 export const useUserAccessibleGroups = () => {
   const { userInfo } = useUserInfo();
   const {
-    /** @type {import("../scanning/scanning.js").GroupsResponse} */ data: groups,
+    /** @type {import("../scanning/scanningLib.js").GroupsResponse} */ data: groups,
     status,
     error,
   } = useQuery({
@@ -256,12 +206,12 @@ export const useQueryParams = () => {
 /**
  * @param {Object} props
  * @param {string} props.sourceId
- * @returns {{photometry: import("../scanning/scanning.js").Photometry[]|undefined, status: QueryStatus, error: any|undefined}}
+ * @returns {{photometry: import("../scanning/scanningLib.js").Photometry[]|undefined, status: QueryStatus, error: any|undefined}}
  */
 export const useSourcePhotometry = ({ sourceId }) => {
   const { userInfo } = useUserInfo();
   const {
-    /** @type {import("../scanning/scanning.js").Photometry[]} */ data: photometry,
+    /** @type {import("../scanning/scanningLib.js").Photometry[]} */ data: photometry,
     status,
     error,
   } = useQuery({

--- a/src/scanning/scanningHooks.js
+++ b/src/scanning/scanningHooks.js
@@ -9,7 +9,7 @@ import { useUserInfo } from "../common/hooks.js";
  * @param {string|null} [props.endDate=null]
  * @param {import("../common/constants").SavedStatus} props.savedStatus
  * @param {string} props.groupIDs
- * @returns {{candidates: import("../scanning/scanningLib.js").Candidate[]|undefined, status: import("@tanstack/react-query").QueryStatus, error: any}}
+ * @returns {{candidateSearchResponse: import("./scanningRequests.js").CandidateSearchResponse|undefined, status: import("@tanstack/react-query").QueryStatus, error: any}}
  */
 export const useSearchCandidates = ({
   startDate,
@@ -19,7 +19,7 @@ export const useSearchCandidates = ({
 }) => {
   const { userInfo } = useUserInfo();
   const {
-    /** @type {import("../scanning/scanningLib.js").Candidate[]} */ data: candidates,
+    /** @type {import("../scanning/scanningLib.js").Candidate[]} */ data: candidateSearchResponse,
     status,
     error,
   } = useQuery({
@@ -46,7 +46,7 @@ export const useSearchCandidates = ({
     enabled: !!userInfo && !!startDate,
   });
   return {
-    candidates,
+    candidateSearchResponse,
     status,
     error,
   };

--- a/src/scanning/scanningHooks.js
+++ b/src/scanning/scanningHooks.js
@@ -9,6 +9,7 @@ import { useUserInfo } from "../common/hooks.js";
  * @param {string|null} [props.endDate=null]
  * @param {import("../common/constants").SavedStatus} props.savedStatus
  * @param {string} props.groupIDs
+ * @param {number} [props.numPerPage=7]
  * @returns {{candidateSearchResponse: import("./scanningRequests.js").CandidateSearchResponse|undefined, status: import("@tanstack/react-query").QueryStatus, error: any}}
  */
 export const useSearchCandidates = ({
@@ -16,6 +17,7 @@ export const useSearchCandidates = ({
   endDate = null,
   savedStatus,
   groupIDs,
+  numPerPage = 7,
 }) => {
   const { userInfo } = useUserInfo();
   const {
@@ -41,6 +43,7 @@ export const useSearchCandidates = ({
         endDate,
         savedStatus,
         groupIDs,
+        numPerPage: numPerPage.toString(),
       });
     },
     enabled: !!userInfo && !!startDate,

--- a/src/scanning/scanningHooks.js
+++ b/src/scanning/scanningHooks.js
@@ -9,7 +9,7 @@ import { useUserInfo } from "../common/hooks.js";
  * @param {string|null} [props.endDate=null]
  * @param {import("../common/constants").SavedStatus} props.savedStatus
  * @param {string} props.groupIDs
- * @param {number} [props.numPerPage=7]
+ * @param {number} props.numPerPage
  * @returns {{candidateSearchResponse: import("./scanningRequests.js").CandidateSearchResponse|undefined, status: import("@tanstack/react-query").QueryStatus, error: any}}
  */
 export const useSearchCandidates = ({
@@ -17,7 +17,7 @@ export const useSearchCandidates = ({
   endDate = null,
   savedStatus,
   groupIDs,
-  numPerPage = 7,
+  numPerPage,
 }) => {
   const { userInfo } = useUserInfo();
   const {
@@ -44,6 +44,7 @@ export const useSearchCandidates = ({
         savedStatus,
         groupIDs,
         numPerPage: numPerPage.toString(),
+        pageNumber: "1",
       });
     },
     enabled: !!userInfo && !!startDate,

--- a/src/scanning/scanningHooks.js
+++ b/src/scanning/scanningHooks.js
@@ -1,0 +1,53 @@
+import { useQuery } from "@tanstack/react-query";
+import { QUERY_KEYS } from "../common/constants.js";
+import { searchCandidates } from "./scanningRequests.js";
+import { useUserInfo } from "../common/hooks.js";
+
+/**
+ * @param {Object} props
+ * @param {string} props.startDate
+ * @param {string|null} [props.endDate=null]
+ * @param {import("../common/constants").SavedStatus} props.savedStatus
+ * @param {string} props.groupIDs
+ * @returns {{candidates: import("../scanning/scanningLib.js").Candidate[]|undefined, status: import("@tanstack/react-query").QueryStatus, error: any}}
+ */
+export const useSearchCandidates = ({
+  startDate,
+  endDate = null,
+  savedStatus,
+  groupIDs,
+}) => {
+  const { userInfo } = useUserInfo();
+  const {
+    /** @type {import("../scanning/scanningLib.js").Candidate[]} */ data: candidates,
+    status,
+    error,
+  } = useQuery({
+    queryKey: [
+      QUERY_KEYS.CANDIDATES,
+      startDate,
+      endDate,
+      savedStatus,
+      groupIDs,
+    ],
+    queryFn: async () => {
+      if (!startDate || !endDate || !savedStatus || !groupIDs) {
+        throw new Error("Missing parameters");
+      }
+      return await searchCandidates({
+        instanceUrl: userInfo?.instance.url ?? "",
+        token: userInfo?.token ?? "",
+        startDate,
+        endDate,
+        savedStatus,
+        groupIDs,
+      });
+    },
+    enabled: !!userInfo && !!startDate,
+  });
+  return {
+    candidates,
+    status,
+    error,
+  };
+};

--- a/src/scanning/scanningLib.js
+++ b/src/scanning/scanningLib.js
@@ -1,6 +1,3 @@
-import mockCandidates from "../../mock/candidates.json";
-import { Capacitor, CapacitorHttp } from "@capacitor/core";
-
 /**
  * @typedef {Object} CandidateThumbnail
  * @property {string} type - Thumbnail type
@@ -134,47 +131,6 @@ export const getThumbnailHeader = (type) => {
 };
 
 /**
- * Returns the candidates from the API
- * @param {Object} params
- * @param {string} params.instanceUrl - The URL of the instance
- * @param {string} params.token - The token to use to fetch the candidates
- * @param {string} params.startDate - The start date of the candidates
- * @param {string|null} [params.endDate=null] - The end date of the candidates
- * @param {import("../common/constants").SavedStatus} params.savedStatus - The saved status of the candidates
- * @param {string} params.groupIDs - The group IDs to search for
- * @returns {Promise<Candidate[]>}
- */
-export async function searchCandidates({
-  instanceUrl,
-  token,
-  startDate,
-  endDate,
-  savedStatus,
-  groupIDs,
-}) {
-  // example: https://preview.fritz.science/api/candidates?pageNumber=1&numPerPage=50&groupIDs=4&savedStatus=savedToAnySelected&listNameReject=rejected_candidates&startDate=2024-07-01T21%3A27%3A27.232Z
-  if (Capacitor.getPlatform() === "web") {
-    return mockCandidates.data.candidates;
-  }
-  let response = await CapacitorHttp.get({
-    url: `${instanceUrl}/api/candidates`,
-    headers: {
-      Authorization: `token ${token}`,
-    },
-    params: {
-      pageNumber: "1",
-      numPerPage: "50",
-      groupIDs,
-      savedStatus,
-      listNameReject: "rejected_candidates",
-      startDate,
-      endDate: endDate || "",
-    },
-  });
-  return response.data.data.candidates;
-}
-
-/**
  * Get the URL of the thumbnail image
  * @param {Candidate} candidate
  * @param {string} type
@@ -190,22 +146,6 @@ export function getThumbnailImageUrl(candidate, type) {
     res = "https://preview.fritz.science" + res;
   }
   return res;
-}
-
-/**
- * @param {Object} params
- * @param {string} params.instanceUrl
- * @param {string} params.token
- * @returns {Promise<GroupsResponse>}
- */
-export async function fetchGroups({ instanceUrl, token }) {
-  let response = await CapacitorHttp.get({
-    url: `${instanceUrl}/api/groups`,
-    headers: {
-      Authorization: `token ${token}`,
-    },
-  });
-  return response.data.data;
 }
 
 /**
@@ -427,37 +367,4 @@ export const getVegaPlotSpec = ({
       },
     ],
   });
-};
-
-/**
- * Fetch the photometry of a source
- * @param {Object} params
- * @param {string} params.sourceId - The source ID
- * @param {string} params.instanceUrl - The URL of the instance
- * @param {string} params.token - The token to use to fetch the photometry
- * @param {string} [params.includeOwnerInfo="true"] - Include owner info
- * @param {string} [params.includeStreamInfo="true"] - Include stream info
- * @param {string} [params.includeValidationInfo="true"] - Include validation info
- * @returns {Promise<Photometry[]>}
- */
-export const fetchSourcePhotometry = async ({
-  sourceId,
-  instanceUrl,
-  token,
-  includeOwnerInfo = "true",
-  includeStreamInfo = "true",
-  includeValidationInfo = "true",
-}) => {
-  let response = await CapacitorHttp.get({
-    url: `${instanceUrl}/api/sources/${sourceId}/photometry`,
-    headers: {
-      Authorization: `token ${token}`,
-    },
-    params: {
-      includeOwnerInfo,
-      includeStreamInfo,
-      includeValidationInfo,
-    },
-  });
-  return response.data.data;
 };

--- a/src/scanning/scanningLib.js
+++ b/src/scanning/scanningLib.js
@@ -63,6 +63,10 @@
  * @typedef {"new" | "ref" | "sub" | "sdss" | "ls" | "ps1"} ThumbnailType
  */
 
+import { Clipboard } from "@capacitor/clipboard";
+import { useIonToast } from "@ionic/react";
+import { useCallback } from "react";
+
 /**
  * @type {Object<ThumbnailType, ThumbnailType>}
  */
@@ -367,4 +371,24 @@ export const getVegaPlotSpec = ({
       },
     ],
   });
+};
+
+export const useCopyAnnotationLineOnClick = () => {
+  const [present] = useIonToast();
+  return useCallback(
+    /**
+     * @param {string} key
+     * @param {string|number|undefined} value
+     */
+    async (key, value) => {
+      await Clipboard.write({
+        string: `${key}: ${value}`,
+      });
+      await present({
+        message: "Annotation copied to clipboard!",
+        duration: 2000,
+      });
+    },
+    [present],
+  );
 };

--- a/src/scanning/scanningOptions/ScanningOptionsDiscarding/ScanningOptionsDiscarding.jsx
+++ b/src/scanning/scanningOptions/ScanningOptionsDiscarding/ScanningOptionsDiscarding.jsx
@@ -20,7 +20,7 @@ import { ControlledRadioGroup } from "../../../common/ControlledRadioGroup/Contr
  * @param {Partial<import("react-hook-form").FieldErrorsImpl<import("react-hook-form").DeepRequired<import("react-hook-form").FieldValues>>> & {root?: Record<string, import("react-hook-form").GlobalError> & import("react-hook-form").GlobalError}} props.errors
  * @param {import("react-hook-form").Control<any,any>} props.control
  * @param {import("react-hook-form").UseFormWatch<any>} props.watch
- * @param {import("../../scanning.js").Group[]} props.userAccessibleGroups
+ * @param {import("../../scanningLib.js").Group[]} props.userAccessibleGroups
  * @param {React.MutableRefObject<any>} props.modal
  * @returns {JSX.Element}
  */
@@ -32,7 +32,7 @@ export const ScanningOptionsDiscarding = ({
   userAccessibleGroups,
   modal,
 }) => {
-  /** @type {import("../../scanning.js").Group[]} */
+  /** @type {import("../../scanningLib.js").Group[]} */
   const junkGroups = watch("junkGroups").map(
     (/** @type {string[]} */ groupId) =>
       userAccessibleGroups.find((group) => group.id === +groupId),
@@ -49,7 +49,7 @@ export const ScanningOptionsDiscarding = ({
           .map((/** @type {string} */ groupId) =>
             userAccessibleGroups.find((group) => group.id === +groupId),
           )
-          .map((/** @type {import("../../scanning.js").Group} */ group) => (
+          .map((/** @type {import("../../scanningLib.js").Group} */ group) => (
             <IonChip key={group.id}>{group.name}</IonChip>
           ))}
         <IonModal
@@ -121,7 +121,7 @@ export const ScanningOptionsDiscarding = ({
                 >
                   {junkGroups.map(
                     (
-                      /** @type {import("../../scanning.js").Group} */ group,
+                      /** @type {import("../../scanningLib.js").Group} */ group,
                     ) => (
                       <IonSelectOption key={group.id} value={group.id}>
                         {group.name}

--- a/src/scanning/scanningOptions/ScanningOptionsProgram/ScanningOptionsProgram.jsx
+++ b/src/scanning/scanningOptions/ScanningOptionsProgram/ScanningOptionsProgram.jsx
@@ -9,7 +9,7 @@ import { ErrorMessage } from "../../../common/ErrorMessage/ErrorMessage.jsx";
 /**
  * Program selection section of the scanning options
  * @param {Object} props
- * @param {import("../../scanning.js").Group[]} props.userAccessibleGroups
+ * @param {import("../../scanningLib.js").Group[]} props.userAccessibleGroups
  * @param {React.MutableRefObject<any>} props.modal
  * @param {import("react-hook-form").Control<any,any>} props.control
  * @param {import("react-hook-form").UseFormWatch<any>} props.watch
@@ -37,7 +37,7 @@ export const ScanningOptionsProgram = ({
           .map((/** @type {string} */ groupId) =>
             userAccessibleGroups.find((group) => group.id === +groupId),
           )
-          .map((/** @type {import("../../scanning.js").Group} */ group) => (
+          .map((/** @type {import("../../scanningLib.js").Group} */ group) => (
             <IonChip key={group.id}>{group.name}</IonChip>
           ))}
         <IonModal

--- a/src/scanning/scanningRequests.js
+++ b/src/scanning/scanningRequests.js
@@ -17,8 +17,8 @@ import { CapacitorHttp } from "@capacitor/core";
  * @param {import("../common/constants").SavedStatus} params.savedStatus - The saved status of the candidates
  * @param {string} params.groupIDs - The group IDs to search for
  * @param {string|null} [params.queryID=null] - The query ID
- * @param {string} [params.pageNumber="1"] - The page number
- * @param {string} [params.numPerPage="7"] - The number of candidates per page
+ * @param {string} params.pageNumber - The page number
+ * @param {string} params.numPerPage - The number of candidates per page
  * @returns {Promise<CandidateSearchResponse>}
  */
 export async function searchCandidates({
@@ -29,8 +29,8 @@ export async function searchCandidates({
   savedStatus,
   groupIDs,
   queryID = null,
-  pageNumber = "1",
-  numPerPage = "7",
+  pageNumber,
+  numPerPage,
 }) {
   // example: https://preview.fritz.science/api/candidates?pageNumber=1&numPerPage=50&groupIDs=4&savedStatus=savedToAnySelected&listNameReject=rejected_candidates&startDate=2024-07-01T21%3A27%3A27.232Z
   let response = await CapacitorHttp.get({

--- a/src/scanning/scanningRequests.js
+++ b/src/scanning/scanningRequests.js
@@ -4,6 +4,7 @@ import { CapacitorHttp } from "@capacitor/core";
  * @typedef {Object} CandidateSearchResponse
  * @property {import("./scanningLib.js").Candidate[]} candidates - The candidates
  * @property {number} totalMatches - The total matches
+ * @property {string} queryID - The query ID
  */
 
 /**
@@ -15,6 +16,9 @@ import { CapacitorHttp } from "@capacitor/core";
  * @param {string|null} [params.endDate=null] - The end date of the candidates
  * @param {import("../common/constants").SavedStatus} params.savedStatus - The saved status of the candidates
  * @param {string} params.groupIDs - The group IDs to search for
+ * @param {string|null} [params.queryID=null] - The query ID
+ * @param {string} [params.pageNumber="1"] - The page number
+ * @param {string} [params.numPerPage="7"] - The number of candidates per page
  * @returns {Promise<CandidateSearchResponse>}
  */
 export async function searchCandidates({
@@ -24,6 +28,9 @@ export async function searchCandidates({
   endDate,
   savedStatus,
   groupIDs,
+  queryID = null,
+  pageNumber = "1",
+  numPerPage = "7",
 }) {
   // example: https://preview.fritz.science/api/candidates?pageNumber=1&numPerPage=50&groupIDs=4&savedStatus=savedToAnySelected&listNameReject=rejected_candidates&startDate=2024-07-01T21%3A27%3A27.232Z
   let response = await CapacitorHttp.get({
@@ -32,18 +39,20 @@ export async function searchCandidates({
       Authorization: `token ${token}`,
     },
     params: {
-      pageNumber: "1",
-      numPerPage: "50",
+      pageNumber,
+      numPerPage,
       groupIDs,
       savedStatus,
       listNameReject: "rejected_candidates",
       startDate,
       endDate: endDate || "",
+      queryID: queryID || "",
     },
   });
   return {
     candidates: response.data.data.candidates,
     totalMatches: response.data.data.totalMatches,
+    queryID: response.data.data.queryID,
   };
 }
 

--- a/src/scanning/scanningRequests.js
+++ b/src/scanning/scanningRequests.js
@@ -1,0 +1,92 @@
+import { Capacitor, CapacitorHttp } from "@capacitor/core";
+import mockCandidates from "../../mock/candidates.json";
+
+/**
+ * Returns the candidates from the API
+ * @param {Object} params
+ * @param {string} params.instanceUrl - The URL of the instance
+ * @param {string} params.token - The token to use to fetch the candidates
+ * @param {string} params.startDate - The start date of the candidates
+ * @param {string|null} [params.endDate=null] - The end date of the candidates
+ * @param {import("../common/constants").SavedStatus} params.savedStatus - The saved status of the candidates
+ * @param {string} params.groupIDs - The group IDs to search for
+ * @returns {Promise<import("./scanningLib.js").Candidate[]>}
+ */
+export async function searchCandidates({
+  instanceUrl,
+  token,
+  startDate,
+  endDate,
+  savedStatus,
+  groupIDs,
+}) {
+  // example: https://preview.fritz.science/api/candidates?pageNumber=1&numPerPage=50&groupIDs=4&savedStatus=savedToAnySelected&listNameReject=rejected_candidates&startDate=2024-07-01T21%3A27%3A27.232Z
+  if (Capacitor.getPlatform() === "web") {
+    return mockCandidates.data.candidates;
+  }
+  let response = await CapacitorHttp.get({
+    url: `${instanceUrl}/api/candidates`,
+    headers: {
+      Authorization: `token ${token}`,
+    },
+    params: {
+      pageNumber: "1",
+      numPerPage: "50",
+      groupIDs,
+      savedStatus,
+      listNameReject: "rejected_candidates",
+      startDate,
+      endDate: endDate || "",
+    },
+  });
+  return response.data.data.candidates;
+}
+
+/**
+ * @param {Object} params
+ * @param {string} params.instanceUrl
+ * @param {string} params.token
+ * @returns {Promise<import("./scanningLib.js").GroupsResponse>}
+ */
+export async function fetchGroups({ instanceUrl, token }) {
+  let response = await CapacitorHttp.get({
+    url: `${instanceUrl}/api/groups`,
+    headers: {
+      Authorization: `token ${token}`,
+    },
+  });
+  return response.data.data;
+}
+
+/**
+ * Fetch the photometry of a source
+ * @param {Object} params
+ * @param {string} params.sourceId - The source ID
+ * @param {string} params.instanceUrl - The URL of the instance
+ * @param {string} params.token - The token to use to fetch the photometry
+ * @param {string} [params.includeOwnerInfo="true"] - Include owner info
+ * @param {string} [params.includeStreamInfo="true"] - Include stream info
+ * @param {string} [params.includeValidationInfo="true"] - Include validation info
+ * @returns {Promise<import("./scanningLib.js").Photometry[]>}
+ */
+export const fetchSourcePhotometry = async ({
+  sourceId,
+  instanceUrl,
+  token,
+  includeOwnerInfo = "true",
+  includeStreamInfo = "true",
+  includeValidationInfo = "true",
+}) => {
+  let response = await CapacitorHttp.get({
+    url: `${instanceUrl}/api/sources/${sourceId}/photometry`,
+    headers: {
+      Authorization: `token ${token}`,
+    },
+    params: {
+      includeOwnerInfo,
+      includeStreamInfo,
+      includeValidationInfo,
+    },
+  });
+  return response.data.data;
+};

--- a/src/scanning/scanningRequests.js
+++ b/src/scanning/scanningRequests.js
@@ -1,5 +1,10 @@
-import { Capacitor, CapacitorHttp } from "@capacitor/core";
-import mockCandidates from "../../mock/candidates.json";
+import { CapacitorHttp } from "@capacitor/core";
+
+/**
+ * @typedef {Object} CandidateSearchResponse
+ * @property {import("./scanningLib.js").Candidate[]} candidates - The candidates
+ * @property {number} totalMatches - The total matches
+ */
 
 /**
  * Returns the candidates from the API
@@ -10,7 +15,7 @@ import mockCandidates from "../../mock/candidates.json";
  * @param {string|null} [params.endDate=null] - The end date of the candidates
  * @param {import("../common/constants").SavedStatus} params.savedStatus - The saved status of the candidates
  * @param {string} params.groupIDs - The group IDs to search for
- * @returns {Promise<import("./scanningLib.js").Candidate[]>}
+ * @returns {Promise<CandidateSearchResponse>}
  */
 export async function searchCandidates({
   instanceUrl,
@@ -21,9 +26,6 @@ export async function searchCandidates({
   groupIDs,
 }) {
   // example: https://preview.fritz.science/api/candidates?pageNumber=1&numPerPage=50&groupIDs=4&savedStatus=savedToAnySelected&listNameReject=rejected_candidates&startDate=2024-07-01T21%3A27%3A27.232Z
-  if (Capacitor.getPlatform() === "web") {
-    return mockCandidates.data.candidates;
-  }
   let response = await CapacitorHttp.get({
     url: `${instanceUrl}/api/candidates`,
     headers: {
@@ -39,7 +41,10 @@ export async function searchCandidates({
       endDate: endDate || "",
     },
   });
-  return response.data.data.candidates;
+  return {
+    candidates: response.data.data.candidates,
+    totalMatches: response.data.data.totalMatches,
+  };
 }
 
 /**

--- a/src/scanning/scanningSession/CandidateAnnotationItem/CandidateAnnotationItem.jsx
+++ b/src/scanning/scanningSession/CandidateAnnotationItem/CandidateAnnotationItem.jsx
@@ -11,7 +11,7 @@ import { useCallback } from "react";
 
 /**
  * @param {Object} props
- * @param {import("../../scanning").CandidateAnnotation} props.annotation
+ * @param {import("../../scanningLib.js").CandidateAnnotation} props.annotation
  * @returns {JSX.Element}
  */
 export const CandidateAnnotationItem = ({ annotation }) => {

--- a/src/scanning/scanningSession/CandidateAnnotationItem/CandidateAnnotationItem.jsx
+++ b/src/scanning/scanningSession/CandidateAnnotationItem/CandidateAnnotationItem.jsx
@@ -1,13 +1,6 @@
 import "./CandidateAnnotationItem.scss";
-import {
-  IonItem,
-  IonLabel,
-  IonList,
-  IonListHeader,
-  useIonToast,
-} from "@ionic/react";
-import { Clipboard } from "@capacitor/clipboard";
-import { useCallback } from "react";
+import { IonItem, IonLabel, IonList, IonListHeader } from "@ionic/react";
+import { useCopyAnnotationLineOnClick } from "../../scanningLib.js";
 
 /**
  * @param {Object} props
@@ -15,22 +8,7 @@ import { useCallback } from "react";
  * @returns {JSX.Element}
  */
 export const CandidateAnnotationItem = ({ annotation }) => {
-  const [present] = useIonToast();
-  const handleTextCopied = useCallback(
-    async (
-      /** @type {string} */ key,
-      /** @type {string|number|undefined} */ value,
-    ) => {
-      await Clipboard.write({
-        string: `${key}: ${value}`,
-      });
-      await present({
-        message: "Text copied to clipboard!",
-        duration: 2000,
-      });
-    },
-    [present],
-  );
+  const handleTextCopied = useCopyAnnotationLineOnClick();
 
   return (
     <div className="candidate-annotation-item">

--- a/src/scanning/scanningSession/CandidateAnnotations/CandidateAnnotations.jsx
+++ b/src/scanning/scanningSession/CandidateAnnotations/CandidateAnnotations.jsx
@@ -3,7 +3,7 @@ import { CandidateAnnotationItem } from "../CandidateAnnotationItem/CandidateAnn
 
 /**
  * @param {Object} props
- * @param {import("../../scanning").Candidate} props.candidate
+ * @param {import("../../scanningLib.js").Candidate} props.candidate
  * @returns {JSX.Element}
  */
 export const CandidateAnnotations = ({ candidate }) => {

--- a/src/scanning/scanningSession/CandidateAnnotationsViewer/CandidateAnnotationsViewer.jsx
+++ b/src/scanning/scanningSession/CandidateAnnotationsViewer/CandidateAnnotationsViewer.jsx
@@ -3,7 +3,7 @@ import { CandidateAnnotations } from "../CandidateAnnotations/CandidateAnnotatio
 
 /**
  * @param {Object} props
- * @param {import("../../scanning").Candidate} props.candidate
+ * @param {import("../../scanningLib.js").Candidate} props.candidate
  * @returns {JSX.Element}
  */
 export const CandidateAnnotationsViewer = ({ candidate }) => {

--- a/src/scanning/scanningSession/CandidatePhotometryChart/CandidatePhotometryChart.jsx
+++ b/src/scanning/scanningSession/CandidatePhotometryChart/CandidatePhotometryChart.jsx
@@ -1,7 +1,7 @@
 import "./CandidatePhotometryChart.scss";
 import { useEffect, useRef, useState } from "react";
 import embed from "vega-embed";
-import { getVegaPlotSpec } from "../../scanning.js";
+import { getVegaPlotSpec } from "../../scanningLib.js";
 import {
   useBandpassesColors,
   useSourcePhotometry,
@@ -10,7 +10,7 @@ import { IonSpinner } from "@ionic/react";
 
 /**
  * @param {Object} props
- * @param {import("../../scanning.js").Candidate} props.candidate
+ * @param {import("../../scanningLib.js").Candidate} props.candidate
  * @returns {JSX.Element}
  */
 export const CandidatePhotometryChart = ({ candidate }) => {

--- a/src/scanning/scanningSession/CandidatePhotometryChart/CandidatePhotometryChart.jsx
+++ b/src/scanning/scanningSession/CandidatePhotometryChart/CandidatePhotometryChart.jsx
@@ -6,7 +6,7 @@ import {
   useBandpassesColors,
   useSourcePhotometry,
 } from "../../../common/hooks.js";
-import { IonSpinner } from "@ionic/react";
+import { IonSkeletonText } from "@ionic/react";
 
 /**
  * @param {Object} props
@@ -64,7 +64,7 @@ export const CandidatePhotometryChart = ({ candidate }) => {
     };
   }, [container, status]);
   return (
-    <>
+    <div className="candidate-photometry-chart">
       <div
         className="canvas-container"
         ref={container}
@@ -72,10 +72,12 @@ export const CandidatePhotometryChart = ({ candidate }) => {
       />
       <div
         className={`canvas-loading ${hasLoaded ? "loaded" : "loading"}`}
-        style={{ visibility: loaderIsHidden ? "hidden" : "visible" }}
+        style={{
+          visibility: loaderIsHidden ? "hidden" : "visible",
+        }}
       >
-        <IonSpinner color="primary" />
+        <IonSkeletonText animated />
       </div>
-    </>
+    </div>
   );
 };

--- a/src/scanning/scanningSession/CandidatePhotometryChart/CandidatePhotometryChart.scss
+++ b/src/scanning/scanningSession/CandidatePhotometryChart/CandidatePhotometryChart.scss
@@ -1,24 +1,31 @@
-.canvas-container {
+.candidate-photometry-chart {
+  display: block;
   height: 100%;
-  width: 100%;
-}
 
-.canvas-loading {
-  display: flex;
-  background: #ffffff;
-  justify-content: center;
-  align-items: center;
-  z-index: 100;
-  position: absolute;
-  top: 0;
-  height: 100%;
-  width: 100%;
-  transition: opacity 0.3s;
-
-  &.loading {
-    opacity: 1;
+  .canvas-container {
+    height: 100%;
+    width: 100%;
   }
-  &.loaded {
-    opacity: 0;
+
+  .canvas-loading {
+    display: flex;
+    flex-direction: column;
+    background: #ffffff;
+    justify-content: center;
+    align-items: center;
+    z-index: 100;
+    position: absolute;
+    top: 0;
+    height: 100%;
+    width: 100%;
+    transition: opacity 0.3s;
+
+    &.loading {
+      opacity: 1;
+    }
+
+    &.loaded {
+      opacity: 0;
+    }
   }
 }

--- a/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
+++ b/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
@@ -1,12 +1,13 @@
 import "./CandidateScanner.scss";
 import { IonButton, IonIcon, IonModal } from "@ionic/react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useQueryParams, useSearchCandidates } from "../../../common/hooks.js";
+import { useQueryParams } from "../../../common/hooks.js";
 import { arrowForward, checkmark, trashBin } from "ionicons/icons";
 import useEmblaCarousel from "embla-carousel-react";
 import { CandidateAnnotationsViewer } from "../CandidateAnnotationsViewer/CandidateAnnotationsViewer.jsx";
 import { ScanningCard } from "../ScanningCard/ScanningCard.jsx";
 import { ScanningCardSkeleton } from "../ScanningCard/ScanningCardSkeleton.jsx";
+import { useSearchCandidates } from "../../scanningHooks.js";
 
 export const CandidateScanner = () => {
   const [currentIndex, setCurrentIndex] = useState(0);

--- a/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
+++ b/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
@@ -14,7 +14,7 @@ import { QUERY_KEYS } from "../../../common/constants.js";
 import { useMutation } from "@tanstack/react-query";
 
 export const CandidateScanner = () => {
-  const numPerPage = 7;
+  const numPerPage = 25;
   const [currentIndex, setCurrentIndex] = useState(0);
   const [totalMatches, setTotalMatches] = useState(0);
   const [emblaRef, emblaApi] = useEmblaCarousel();

--- a/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
+++ b/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
@@ -33,17 +33,15 @@ export const CandidateScanner = () => {
   /** @type {React.MutableRefObject<any>} */
   const modal = useRef(null);
   const queryParams = useQueryParams();
-  const { candidates } = useSearchCandidates({
+  const { candidateSearchResponse } = useSearchCandidates({
     startDate: queryParams.startDate,
     endDate: queryParams.endDate,
     savedStatus: queryParams.savedStatus,
     groupIDs: queryParams.groupIDs,
   });
+  const candidates = candidateSearchResponse?.candidates;
+  const totalMatches = candidateSearchResponse?.totalMatches;
 
-  if (candidates?.length === 0) {
-    return <p>No candidates found</p>;
-  }
-  // @ts-ignore
   const currentCandidate = candidates?.at(currentIndex);
   return (
     <div className="candidate-scanner">
@@ -55,7 +53,8 @@ export const CandidateScanner = () => {
                 candidate={candidate}
                 modal={modal}
                 currentIndex={index}
-                nbCandidates={candidates.length}
+                // @ts-ignore
+                nbCandidates={totalMatches}
                 emblaApi={emblaApi}
               />
             </div>

--- a/src/scanning/scanningSession/CandidateScanner/CandidateScanner.scss
+++ b/src/scanning/scanningSession/CandidateScanner/CandidateScanner.scss
@@ -5,8 +5,7 @@
   height: 100%;
 
   .embla {
-    display: flex;
-    flex-direction: column;
+    display: block;
     grid-row: 1/2;
     grid-column: 1/2;
     width: 100vw;

--- a/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.jsx
+++ b/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.jsx
@@ -3,7 +3,7 @@ import { IonButton, IonText } from "@ionic/react";
 
 /**
  * @param {Object} props
- * @param {import("../../scanning").Candidate} props.candidate
+ * @param {import("../../scanningLib.js").Candidate} props.candidate
  * @param {() => void} props.onButtonClick
  * @param {string[]} [props.pinnedAnnotationIds]
  * @returns {JSX.Element}

--- a/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.jsx
+++ b/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.jsx
@@ -1,5 +1,6 @@
 import "./PinnedAnnotations.scss";
-import { IonButton, IonText } from "@ionic/react";
+import { IonButton, IonItem, IonText } from "@ionic/react";
+import { useCopyAnnotationLineOnClick } from "../../scanningLib.js";
 
 /**
  * @param {Object} props
@@ -17,6 +18,7 @@ export const PinnedAnnotations = ({
     "ZTF Science Validation:Public Transients.acai_h",
   ],
 }) => {
+  const handleTextCopied = useCopyAnnotationLineOnClick();
   const pinnedAnnotations = pinnedAnnotationIds.map((id) => {
     const [annotationOrigin, dataItem] = id.split(".");
     return {
@@ -31,24 +33,34 @@ export const PinnedAnnotations = ({
     <div className="pinned-annotations">
       <div className="annotations">
         {pinnedAnnotations.map((annotationLine) => (
-          <div key={annotationLine.id} className="annotation-line">
+          <IonItem
+            key={annotationLine.id}
+            className="annotation-line"
+            lines="none"
+            onClick={() =>
+              handleTextCopied(annotationLine.id, annotationLine.value)
+            }
+            button
+          >
             <IonText className="name" color="secondary">
               {annotationLine.id}:
             </IonText>
+            {"\u00A0"}
             <div>{annotationLine.value}</div>
-          </div>
+          </IonItem>
         ))}
       </div>
-      <IonButton
-        onClick={onButtonClick}
-        color="secondary"
-        expand="block"
-        shape="round"
-        size="small"
-        fill="clear"
-      >
-        Show all
-      </IonButton>
+      <div className="button-container">
+        <IonButton
+          onClick={onButtonClick}
+          color="secondary"
+          expand="block"
+          size="small"
+          fill="clear"
+        >
+          Show all
+        </IonButton>
+      </div>
     </div>
   );
 };

--- a/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.scss
+++ b/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.scss
@@ -3,12 +3,12 @@
   justify-content: center;
   align-items: center;
   width: 100%;
-  padding: 0 0.5rem;
+  padding: 0.5rem;
   border: 0.5px rgba(82, 100, 117, 0.3) solid;
   align-self: center;
   border-radius: 0.5rem;
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.1);
-  height: 9.2vh;
+  height: 10vh;
 
   .annotations {
     display: flex;
@@ -16,11 +16,29 @@
     justify-content: space-around;
     flex: 1;
     gap: 0.1rem;
+    height: 100%;
+
+    ion-item {
+      --background: none;
+      --inner-padding-bottom: 0.5rem;
+      --inner-padding-top: 0.5rem;
+      --padding-start: 0.2rem;
+      --min-height: 0;
+    }
+
+    &.skeleton {
+      gap: 0.3rem;
+    }
 
     .annotation-line {
       display: flex;
       gap: 0.5rem;
       font-size: 0.9rem;
     }
+  }
+
+  .button-container {
+    display: flex;
+    height: 100%;
   }
 }

--- a/src/scanning/scanningSession/PinnedAnnotationsSkeleton/PinnedAnnotationsSkeleton.jsx
+++ b/src/scanning/scanningSession/PinnedAnnotationsSkeleton/PinnedAnnotationsSkeleton.jsx
@@ -9,12 +9,12 @@ import { IonSkeletonText } from "@ionic/react";
 export const PinnedAnnotationsSkeleton = ({ animated }) => {
   return (
     <div className="pinned-annotations">
-      <div className="annotations">
+      <div className="annotations skeleton">
         {[1, 2, 3].map((index) => (
           <div key={index} className="annotation-line">
             <IonSkeletonText
               className="name"
-              style={{ width: "2rem" }}
+              style={{ width: "2rem", height: ".8rem" }}
               animated={animated}
             />
             <IonSkeletonText style={{ width: "11rem" }} animated={animated} />

--- a/src/scanning/scanningSession/ScanningCard/ScanningCard.jsx
+++ b/src/scanning/scanningSession/ScanningCard/ScanningCard.jsx
@@ -1,5 +1,5 @@
 import "./ScanningCard.scss";
-import { THUMBNAIL_TYPES } from "../../scanning.js";
+import { THUMBNAIL_TYPES } from "../../scanningLib.js";
 import { Thumbnail } from "../Thumbnail/Thumbnail.jsx";
 import { PinnedAnnotations } from "../PinnedAnnotations/PinnedAnnotations.jsx";
 import { CandidatePhotometryChart } from "../CandidatePhotometryChart/CandidatePhotometryChart.jsx";
@@ -9,7 +9,7 @@ import { ScanningCardSkeleton } from "./ScanningCardSkeleton.jsx";
 /**
  * Scanning card component
  * @param {Object} props
- * @param {import("../../scanning").Candidate} props.candidate
+ * @param {import("../../scanningLib.js").Candidate} props.candidate
  * @param {React.MutableRefObject<any>} props.modal
  * @param {number} props.currentIndex
  * @param {number} props.nbCandidates

--- a/src/scanning/scanningSession/ScanningCard/ScanningCard.scss
+++ b/src/scanning/scanningSession/ScanningCard/ScanningCard.scss
@@ -11,7 +11,7 @@
     grid-template-rows: 4% 40% 12% 44%;
     padding: 0.5rem;
     margin: 0.4rem 0.4rem 0;
-    border-radius: 15px;
+    border-radius: 1rem;
     background-color: #ffffff;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 
@@ -43,11 +43,20 @@
     }
 
     .plot-container {
+      display: flex;
+      flex-direction: column;
       flex: 1;
       max-height: 40vh;
       width: 100%;
       overflow: hidden;
       position: relative;
+
+      ion-skeleton-text {
+        display: flex;
+        border-radius: 0.6rem;
+        margin-top: 0.2rem;
+        flex: 1;
+      }
     }
   }
 }

--- a/src/scanning/scanningSession/ScanningCard/ScanningCard.scss
+++ b/src/scanning/scanningSession/ScanningCard/ScanningCard.scss
@@ -39,7 +39,8 @@
       display: flex;
       flex-wrap: wrap;
       justify-content: space-between;
-      gap: 0.12rem;
+      height: fit-content;
+      row-gap: 0.3rem;
     }
 
     .plot-container {

--- a/src/scanning/scanningSession/ScanningCard/ScanningCardSkeleton.jsx
+++ b/src/scanning/scanningSession/ScanningCard/ScanningCardSkeleton.jsx
@@ -27,10 +27,7 @@ export const ScanningCardSkeleton = ({ animated = false }) => {
       </div>
       <PinnedAnnotationsSkeleton animated={animated} />
       <div className="plot-container">
-        <IonSkeletonText
-          style={{ width: "100%", height: "100%" }}
-          animated={animated}
-        />
+        <IonSkeletonText animated={animated} />
       </div>
     </div>
   );

--- a/src/scanning/scanningSession/ScanningCard/ScanningCardSkeleton.jsx
+++ b/src/scanning/scanningSession/ScanningCard/ScanningCardSkeleton.jsx
@@ -1,6 +1,6 @@
 import "./ScanningCard.scss";
 import { IonSkeletonText } from "@ionic/react";
-import { THUMBNAIL_TYPES } from "../../scanning.js";
+import { THUMBNAIL_TYPES } from "../../scanningLib.js";
 import { ThumbnailSkeleton } from "../ThumnailSkeleton/ThumbnailSkeleton.jsx";
 import { PinnedAnnotationsSkeleton } from "../PinnedAnnotationsSkeleton/PinnedAnnotationsSkeleton.jsx";
 

--- a/src/scanning/scanningSession/Thumbnail/Thumbnail.jsx
+++ b/src/scanning/scanningSession/Thumbnail/Thumbnail.jsx
@@ -3,13 +3,13 @@ import {
   getThumbnailAltAndSurveyLink,
   getThumbnailHeader,
   getThumbnailImageUrl,
-} from "../../scanning.js";
+} from "../../scanningLib.js";
 import { useState } from "react";
 
 /**
  * Thumbnail component
  * @param {Object} props
- * @param {import("../../scanning").Candidate} props.candidate
+ * @param {import("../../scanningLib.js").Candidate} props.candidate
  * @param {string} props.type
  */
 export const Thumbnail = ({ candidate, type }) => {

--- a/src/scanning/scanningSession/Thumbnail/Thumbnail.scss
+++ b/src/scanning/scanningSession/Thumbnail/Thumbnail.scss
@@ -4,6 +4,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  height: fit-content;
 
   .thumbnail-name {
     font-size: 0.6rem;

--- a/src/scanning/scanningSession/ThumnailSkeleton/ThumbnailSkeleton.jsx
+++ b/src/scanning/scanningSession/ThumnailSkeleton/ThumbnailSkeleton.jsx
@@ -1,6 +1,6 @@
 import "../Thumbnail/Thumbnail.scss";
 import { IonSkeletonText } from "@ionic/react";
-import { getThumbnailHeader } from "../../scanning.js";
+import { getThumbnailHeader } from "../../scanningLib.js";
 
 /**
  * @param {Object} props


### PR DESCRIPTION
The added functionality is to continuously fetch small batches of candidates as the user is swiping through them rather that fetching them all at once. [embla-carrousel](https://www.embla-carousel.com/) does not have this feature natively so I had to do it manually using callbacks that trigger fetching when the user is almost at the end of the list. The feature shows good performance when swiping at a normal, realistic speed. If the user tries to speed run through the candidates, it will block at the end until the next batch arrives.

I also added the copy-on-click behavior to the pinned annotations as the user will likely want to copy the pinned annotations more than the ones in the list and it seemed troublesome to have to open the full list to copy annotations that are directly accessible there in the card.

Small visual details have also been fixed like the ripple of the SHOW ALL button and the gap between thumbnails.
closes #34 

---
* Break down scanning.js into multiple files
	* New scanningHooks.js and scanningRequests.js files to hold the logic for hooks and requests related to scanning
	* Rename scanning.js into scanningLib.js
* Display real number of candidates in scanning card
	* Change `searchCandidates` and `useSearchCandidates` to return on an object including `totalMatches`
* Conditional rendering of a loading indicator while `candidateSearchResponse` is falsy in CandidateScanner.jsx
* Reorganise hooks in CandidateScanner.jsx
* Get rid of the `pageNumber` state in CandidateScanner.jsx to have only one source of truth
* Replace photometry spinner with a `IonSkeletonText`
* Fix gap and height in thumbnails
* Add copy on click behavior to pinned