### PR TITLE
iOS canvas memory fix

### DIFF
--- a/src/onboarding/OnboardingLower/OnboardingLower.jsx
+++ b/src/onboarding/OnboardingLower/OnboardingLower.jsx
@@ -1,4 +1,10 @@
-import { IonButton, IonIcon, IonSelect, IonSelectOption } from "@ionic/react";
+import {
+  IonButton,
+  IonIcon,
+  IonInput,
+  IonSelect,
+  IonSelectOption,
+} from "@ionic/react";
 import "./OnboardingLower.scss";
 import { INSTANCES, QUERY_PARAMS } from "../../common/constants.js";
 import { useState } from "react";
@@ -11,23 +17,19 @@ import { navigateWithParams } from "../../common/util.js";
 /**
  * The lower part of the onboarding screen
  * @param {Object} props
- * @param {string} props.page - The current page of the onboarding screen
+ * @param {import("../auth").OnboardingPage} props.page - The current page of the onboarding screen
  * @param {Function} props.setPage - The function to set the current page of the onboarding screen
  * @returns {JSX.Element}
  */
 const OnboardingLower = ({ page, setPage }) => {
   const history = useHistory();
   const [instance, setInstance] = useState(null);
-  let token = "test";
-  async function handleScanQRCode() {
-    try {
-      const result = await CapacitorBarcodeScanner.scanBarcode({
-        hint: Html5QrcodeSupportedFormats.QR_CODE,
-      });
-      token = result.ScanResult;
-    } catch (error) {
-      console.error(error);
-    }
+  const [token, setToken] = useState("");
+
+  /**
+   * @param {string} token
+   */
+  const navigateToCheckToken = (token) => {
     navigateWithParams(history, "/check-creds", {
       params: {
         [QUERY_PARAMS.TOKEN]: token,
@@ -35,54 +37,96 @@ const OnboardingLower = ({ page, setPage }) => {
       },
       replace: true,
     });
-  }
+  };
 
-  if (page === "welcome")
-    return (
-      <div className="lower">
-        <IonButton
-          shape="round"
-          size="large"
-          onClick={() => setPage("login")}
-          strong
-        >
-          Log in
-        </IonButton>
-      </div>
-    );
-  else
-    return (
-      <div className="lower">
-        <div className="instance-container">
-          <IonSelect
-            class="select"
-            label={"Instance"}
-            placeholder="Select an instance"
-            onIonChange={(e) => setInstance(e.detail.value)}
-          >
-            {INSTANCES.map((instance) => (
-              <IonSelectOption key={instance.name} value={instance}>
-                {instance.name}
-              </IonSelectOption>
-            ))}
-          </IonSelect>
-        </div>
-        <div className="login-methods">
+  const handleScanQRCode = async () => {
+    try {
+      const result = await CapacitorBarcodeScanner.scanBarcode({
+        hint: Html5QrcodeSupportedFormats.QR_CODE,
+      });
+      setToken(result.ScanResult);
+    } catch (error) {
+      console.error(error);
+    }
+    navigateToCheckToken(token);
+  };
+
+  const handleTypeTokenSubmit = () => {
+    navigateToCheckToken(token);
+  };
+
+  switch (page) {
+    case "welcome":
+      return (
+        <div className="lower">
           <IonButton
-            onClick={() => handleScanQRCode()}
             shape="round"
-            disabled={instance === null}
+            size="large"
+            onClick={() => setPage("login")}
             strong
           >
-            <IonIcon slot="start" icon={qrCode}></IonIcon>
-            Scan QR code
-          </IonButton>
-          <IonButton shape="round" disabled={instance === null} strong>
-            Log in with token
+            Log in
           </IonButton>
         </div>
-      </div>
-    );
+      );
+    case "login":
+      return (
+        <div className="lower">
+          <div className="instance-container">
+            <IonSelect
+              class="select"
+              label={"Instance"}
+              placeholder="Select an instance"
+              onIonChange={(e) => setInstance(e.detail.value)}
+            >
+              {INSTANCES.map((instance) => (
+                <IonSelectOption key={instance.name} value={instance}>
+                  {instance.name}
+                </IonSelectOption>
+              ))}
+            </IonSelect>
+          </div>
+          <div className="login-methods">
+            <IonButton
+              onClick={() => handleScanQRCode()}
+              shape="round"
+              disabled={instance === null}
+              strong
+            >
+              <IonIcon slot="start" icon={qrCode}></IonIcon>
+              Scan QR code
+            </IonButton>
+            <IonButton
+              onClick={() => setPage("type_token")}
+              shape="round"
+              disabled={instance === null}
+              strong
+            >
+              Log in with token
+            </IonButton>
+          </div>
+        </div>
+      );
+    case "type_token":
+      return (
+        <div className="lower">
+          <IonInput
+            label="token"
+            placeholder="Enter your token"
+            // @ts-ignore
+            onInput={(e) => setToken(e.target.value)}
+            value={token}
+          ></IonInput>
+          <IonButton
+            onClick={() => handleTypeTokenSubmit()}
+            shape="round"
+            strong
+          >
+            Log in
+          </IonButton>
+        </div>
+      );
+  }
 };
 
 export default OnboardingLower;

--- a/src/onboarding/OnboardingScreen/OnboardingScreen.jsx
+++ b/src/onboarding/OnboardingScreen/OnboardingScreen.jsx
@@ -5,6 +5,7 @@ import "./OnboardingScreen.scss";
 import { useState } from "react";
 
 const OnboardingScreen = () => {
+  /** @type {[import("../auth").OnboardingPage, Function]} */
   const [page, setPage] = useState("welcome");
   return (
     <IonPage>

--- a/src/onboarding/OnboardingUpper/OnboardingUpper.jsx
+++ b/src/onboarding/OnboardingUpper/OnboardingUpper.jsx
@@ -1,5 +1,10 @@
 import "./OnboardingUpper.scss";
 
+/**
+ * @param {Object} props
+ * @param {import("../auth").OnboardingPage} props.page
+ * @returns {JSX.Element}
+ */
 const OnboardingUpper = ({ page }) => {
   function getTagline() {
     switch (page) {

--- a/src/onboarding/OnboardingUpper/OnboardingUpper.scss
+++ b/src/onboarding/OnboardingUpper/OnboardingUpper.scss
@@ -7,15 +7,25 @@
   gap: 3rem;
 
   .logo-n-text {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+
     h1 {
-      color: #1D3557;
+      color: #1d3557;
       font-size: 2rem;
       font-weight: 700;
+    }
+
+    img {
+      height: 8rem;
+      width: auto;
     }
   }
   .tagline {
     font-size: 1.2rem;
-    color: #457B9D;
+    color: #457b9d;
     text-align: center;
   }
 }

--- a/src/onboarding/auth.js
+++ b/src/onboarding/auth.js
@@ -24,6 +24,10 @@ import mockUser from "../../mock/user.json";
  */
 
 /**
+ * @typedef {"welcome"|"login"|"type_token"} OnboardingPage
+ */
+
+/**
  * Check the token and fetch the user from the API
  * @param {Object} params
  * @param {string} params.token - The token to use to fetch the user

--- a/src/scanning/scanningRequests.js
+++ b/src/scanning/scanningRequests.js
@@ -5,6 +5,7 @@ import { CapacitorHttp } from "@capacitor/core";
  * @property {import("./scanningLib.js").Candidate[]} candidates - The candidates
  * @property {number} totalMatches - The total matches
  * @property {string} queryID - The query ID
+ * @property {string} pageNumber - The page number
  */
 
 /**
@@ -17,8 +18,8 @@ import { CapacitorHttp } from "@capacitor/core";
  * @param {import("../common/constants").SavedStatus} params.savedStatus - The saved status of the candidates
  * @param {string} params.groupIDs - The group IDs to search for
  * @param {string|null} [params.queryID=null] - The query ID
- * @param {string} params.pageNumber - The page number
- * @param {string} params.numPerPage - The number of candidates per page
+ * @param {number} params.pageNumber - The page number
+ * @param {number} params.numPerPage - The number of candidates per page
  * @returns {Promise<CandidateSearchResponse>}
  */
 export async function searchCandidates({
@@ -39,8 +40,8 @@ export async function searchCandidates({
       Authorization: `token ${token}`,
     },
     params: {
-      pageNumber,
-      numPerPage,
+      pageNumber: pageNumber.toString(),
+      numPerPage: numPerPage.toString(),
       groupIDs,
       savedStatus,
       listNameReject: "rejected_candidates",
@@ -53,6 +54,7 @@ export async function searchCandidates({
     candidates: response.data.data.candidates,
     totalMatches: response.data.data.totalMatches,
     queryID: response.data.data.queryID,
+    pageNumber: response.data.data.pageNumber,
   };
 }
 

--- a/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
+++ b/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
@@ -3,7 +3,6 @@ import {
   IonButton,
   IonIcon,
   IonModal,
-  IonSpinner,
   useIonAlert,
   useIonToast,
 } from "@ionic/react";
@@ -47,6 +46,7 @@ export const CandidateScanner = () => {
 
   const { userAccessibleGroups } = useUserAccessibleGroups();
   const [presentToast] = useIonToast();
+  const [presentDiscardAlert] = useIonAlert();
 
   useEffect(() => {
     setScanningConfig({
@@ -294,10 +294,6 @@ export const CandidateScanner = () => {
       }
     }
   }, [currentCandidate, scanningConfig]);
-
-  const [presentDiscardAlert] = useIonAlert();
-
-
 
   return (
     <div className="candidate-scanner">

--- a/src/scanning/scanningSession/CandidateScanner/CandidateScanner.scss
+++ b/src/scanning/scanningSession/CandidateScanner/CandidateScanner.scss
@@ -16,17 +16,24 @@
       backface-visibility: hidden;
       flex: 1;
       height: 100%;
+
+      .embla__slide {
+        display: flex;
+        flex: 0 0 100%;
+        min-width: 0;
+        height: 100%;
+      }
     }
   }
-}
 
-.action-buttons-container {
-  display: flex;
-  padding: 0.5rem 1rem;
-  justify-content: space-between;
-  align-items: center;
+  .action-buttons-container {
+    display: flex;
+    padding: 0.5rem 1rem;
+    justify-content: space-between;
+    align-items: center;
 
-  ion-button {
-    --padding-end: 2.3rem;
+    ion-button {
+      --padding-end: 2.3rem;
+    }
   }
 }

--- a/src/scanning/scanningSession/MainScanningScreen/MainScanningScreen.jsx
+++ b/src/scanning/scanningSession/MainScanningScreen/MainScanningScreen.jsx
@@ -1,10 +1,11 @@
+import "./MainScanningScreen.scss";
 import { IonContent, IonPage, IonSpinner } from "@ionic/react";
 import { CandidateScanner } from "../CandidateScanner/CandidateScanner.jsx";
 import React, { Suspense } from "react";
 
 export const MainScanningScreen = () => {
   return (
-    <IonPage>
+    <IonPage className="main-scanning-screen">
       <IonContent>
         <Suspense
           fallback={

--- a/src/scanning/scanningSession/MainScanningScreen/MainScanningScreen.scss
+++ b/src/scanning/scanningSession/MainScanningScreen/MainScanningScreen.scss
@@ -1,0 +1,6 @@
+.main-scanning-screen {
+  ion-content {
+    --padding-top: var(--ion-safe-area-top) !important;
+    --padding-bottom: var(--ion-safe-area-bottom);
+  }
+}

--- a/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.scss
+++ b/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.scss
@@ -2,13 +2,11 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 100%;
   padding: 0.5rem;
   border: 0.5px rgba(82, 100, 117, 0.3) solid;
   align-self: center;
   border-radius: 0.5rem;
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.1);
-  height: 10vh;
 
   .annotations {
     display: flex;
@@ -16,12 +14,11 @@
     justify-content: space-around;
     flex: 1;
     gap: 0.1rem;
-    height: 100%;
 
     ion-item {
       --background: none;
-      --inner-padding-bottom: 0.5rem;
-      --inner-padding-top: 0.5rem;
+      --inner-padding-bottom: 0;
+      --inner-padding-top: 0;
       --padding-start: 0.2rem;
       --min-height: 0;
     }
@@ -39,6 +36,5 @@
 
   .button-container {
     display: flex;
-    height: 100%;
   }
 }

--- a/src/scanning/scanningSession/ScanningCard/ScanningCard.scss
+++ b/src/scanning/scanningSession/ScanningCard/ScanningCard.scss
@@ -1,63 +1,70 @@
-.embla__slide {
-  display: flex;
-  flex: 0 0 100%;
-  min-width: 0;
+.scanning-card-container {
+  flex: 1;
   height: 100%;
+  position: relative;
+}
 
-  .scanning-card {
+.scanning-card {
+  display: grid;
+  height: 100%;
+  grid-template-rows: auto auto auto 40%;
+  grid-row-gap: 0.5rem;
+  padding: 0.5rem;
+  margin: 0 0.4rem;
+  border-radius: 1rem;
+  background-color: #ffffff;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+
+  &.skeleton {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
+
+  .candidate-name {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    margin-bottom: 0.5rem;
+    padding: 0 0.5rem;
+
+    h1 {
+      font-size: 1rem;
+      font-weight: 700;
+    }
+
+    .pagination-indicator {
+      font-size: 0.8rem;
+      font-weight: 400;
+      color: var(--ion-color-secondary);
+    }
+  }
+
+  .thumbnails-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    height: fit-content;
+    row-gap: 0.3rem;
+  }
+
+  .plot-container {
+    display: flex;
+    flex-direction: column;
     flex: 1;
-    display: grid;
-    height: 100%;
-    grid-template-rows: 4% 40% 12% 44%;
-    padding: 0.5rem;
-    margin: 0.4rem 0.4rem 0;
-    border-radius: 1rem;
-    background-color: #ffffff;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    max-height: 40vh;
+    width: 100%;
+    overflow: hidden;
+    position: relative;
 
-    .candidate-name {
+    ion-skeleton-text {
       display: flex;
-      justify-content: space-between;
-      align-items: center;
-      width: 100%;
-      margin-bottom: 0.5rem;
-      padding: 0 0.5rem;
-
-      h1 {
-        font-size: 1rem;
-        font-weight: 700;
-      }
-
-      .pagination-indicator {
-        font-size: 0.8rem;
-        font-weight: 400;
-        color: var(--ion-color-secondary);
-      }
-    }
-
-    .thumbnails-container {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: space-between;
-      height: fit-content;
-      row-gap: 0.3rem;
-    }
-
-    .plot-container {
-      display: flex;
-      flex-direction: column;
+      border-radius: 0.6rem;
+      margin-top: 0.2rem;
       flex: 1;
-      max-height: 40vh;
-      width: 100%;
-      overflow: hidden;
-      position: relative;
-
-      ion-skeleton-text {
-        display: flex;
-        border-radius: 0.6rem;
-        margin-top: 0.2rem;
-        flex: 1;
-      }
     }
   }
 }

--- a/src/scanning/scanningSession/ScanningCard/ScanningCardSkeleton.jsx
+++ b/src/scanning/scanningSession/ScanningCard/ScanningCardSkeleton.jsx
@@ -7,11 +7,15 @@ import { PinnedAnnotationsSkeleton } from "../PinnedAnnotationsSkeleton/PinnedAn
 /**
  * @param {Object} props
  * @param {boolean} [props.animated=false]
+ * @param {boolean} [props.visible=true]
  * @returns {JSX.Element}
  */
-export const ScanningCardSkeleton = ({ animated = false }) => {
+export const ScanningCardSkeleton = ({ animated = false, visible = true }) => {
   return (
-    <div className="scanning-card">
+    <div
+      className="scanning-card skeleton"
+      style={{ visibility: visible ? "visible" : "hidden" }}
+    >
       <div className="candidate-name">
         <h1>
           <IonSkeletonText style={{ width: "8rem" }} animated={animated} />

--- a/src/scanning/scanningSession/Thumbnail/Thumbnail.jsx
+++ b/src/scanning/scanningSession/Thumbnail/Thumbnail.jsx
@@ -29,6 +29,7 @@ export const Thumbnail = ({ candidate, type }) => {
           alt=""
         />
         <img
+          className="cutout"
           src={src}
           alt={alt}
           onError={() => {

--- a/src/scanning/scanningSession/Thumbnail/Thumbnail.scss
+++ b/src/scanning/scanningSession/Thumbnail/Thumbnail.scss
@@ -4,7 +4,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: fit-content;
+  width: 30%;
 
   .thumbnail-name {
     font-size: 0.6rem;
@@ -13,14 +13,17 @@
   }
 
   .thumbnail-image {
-    display: flex;
+    display: block;
+    width: 100%;
+    aspect-ratio: 1 / 1;
     position: relative;
     border: 0.5px rgba(82, 100, 117, 0.3) solid;
+    overflow: hidden;
 
-    img,
+    img.cutout,
     .thumbnail-skeleton-img {
-      width: 30vw;
-      height: 30vw;
+      width: 100%;
+      height: auto;
     }
 
     .crosshairs {

--- a/src/sources/SourceListScreen/SourceListScreen.jsx
+++ b/src/sources/SourceListScreen/SourceListScreen.jsx
@@ -11,7 +11,7 @@ import { SourceList } from "../SourceList/SourceList.jsx";
 
 export const SourceListScreen = () => {
   return (
-    <IonPage>
+    <IonPage className="source-list-screen">
       <IonContent>
         <IonHeader>
           <IonToolbar>

--- a/src/sources/SourceListScreen/SourceListScreen.scss
+++ b/src/sources/SourceListScreen/SourceListScreen.scss
@@ -1,6 +1,8 @@
-.source-list {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  padding: 1rem;
+.source-list-screen {
+  .source-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
+  }
 }

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -14,6 +14,9 @@ ion-skeleton-text {
   padding: 0;
   box-sizing: border-box;
 }
+ion-content {
+  overflow: hidden;
+}
 .app-loading {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
This fixes the iOS canvas memory problem by dynamically mounting and unmounting the photometry plot as the user is swiping. I also replaced the manual pagination that I was doing with the `useInifiniteQuery` from TanStack. As I tested on an iOS simulator, it was more difficult to authentication with a QR code so I added token authentification too.

Closes #37 

---
* Add token authentication
	* Make token a state variable in OnboardingLower.jsx
	* New `handleTypeTokenSubmit` handler in OnboardingLower.jsx
	* Add case "type_token" for OnboardingLower.jsx
* Lazy load photometry to fix performance issues
	* Add `isInView` parameter to CandidatePhotometryChart.jsx
	* Memoize CandidatePhotometryChart.jsx
	* Fetch photometry in a mutation rather than in the rendering
	* Only pass `candidateId` as a parameter instead of the whole `candidate` to CandidatePhotometryChart.jsx
* Use useInfiniteQuery for fetching candidates
	* Edit `useSearchCandidates` hook to use `useInfiniteQuery`
	* Use result from `useInfiniteQuery` in CandidateScanner.jsx
	* Remove `totalMatches` and `candidates` state variables in CandidateScanner.jsx
	* New `slidesInView` state variable in CandidateScanner.jsx to compute if a card is in view
* Make `pageNumber` and `numPerPage` parameters numbers in `searchCandidates
* Fetch bandpass colors in `useBandpassesColors` instead of doing it during app start
* Add padding to main screen to handle safe areas
* Edit PinnedAnnotations layout
* Embed scanning card content in a container to put the ScanningCardSkeleton.jsx besides it
* Memoize ScanningCard.jsx
* Add visible parameter to ScanningCardSkeleton.jsx
* Add class to SourceListScreen.jsx root div for styling
* Change Thumbnail width to 30%
* Make `thumbnail-image` a `block` and use `aspect-ratio` to make sure it's square
* Hide overflow of ion-content