### PR TITLE
#35 Display recap at the end of the list and fix fetching

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -48,6 +48,7 @@ import { MainScanningScreen } from "./scanning/scanningSession/MainScanningScree
 import { SourceListScreen } from "./sources/SourceListScreen/SourceListScreen.jsx";
 import { compassOutline, list } from "ionicons/icons";
 import { ScanningHome } from "./scanning/ScanningHome/ScanningHome.jsx";
+import { ScanningRecap } from "./scanning/scanningSession/ScanningRecap/ScanningRecap.jsx";
 
 setupIonicReact();
 
@@ -76,9 +77,13 @@ const App = () => {
           <Route path="/scanning/main">
             <MainScanningScreen />
           </Route>
+          <Route path="/scanning/recap">
+            <ScanningRecap />
+          </Route>
           <Route exact path="/scanning">
             <ScanningOptionsScreen />
           </Route>
+
           <Route exact path="/">
             <Redirect to="/onboarding" />
           </Route>

--- a/src/common/hooks.js
+++ b/src/common/hooks.js
@@ -8,7 +8,6 @@ import { fetchSources } from "../sources/sources.js";
 import { getPreference, setPreference } from "./preferences.js";
 import config from "../config.js";
 import { checkTokenAndFetchUser } from "../onboarding/auth.js";
-import { useState } from "react";
 import { fetchConfig } from "./requests.js";
 import { fetchGroups } from "../scanning/scanningRequests.js";
 
@@ -90,12 +89,6 @@ export const useFetchSources = ({ page, numPerPage }) => {
 /** @typedef {{user: null|import("../onboarding/auth.js").User, status: QueryStatus, error: any}} SkipOnboardingState */
 
 export const useAppStart = () => {
-  const [state, setState] =
-    /** @type {ReturnType<typeof useState<SkipOnboardingState>>} */ useState({
-      user: null,
-      status: "pending",
-      error: undefined,
-    });
   const queryClient = useQueryClient();
   const appStarted = async () => {
     if (config.CLEAR_AUTH) {
@@ -127,7 +120,7 @@ export const useAppStart = () => {
     };
     queryClient.setQueryData([QUERY_KEYS.USER_INFO], userInfo);
     await setPreference({ key: QUERY_KEYS.USER_INFO, value: userInfo });
-    setState({ user, status: "success", error: state.error });
+    return user;
   };
   return useQuery({
     // @ts-ignore

--- a/src/onboarding/OnboardingLower/OnboardingLower.scss
+++ b/src/onboarding/OnboardingLower/OnboardingLower.scss
@@ -3,8 +3,8 @@
   flex: 1;
   flex-direction: column;
   justify-content: center;
-  padding: 0 2rem;
-  gap: 4rem;
+  padding: 0 1rem;
+  gap: 3rem;
 
   .instance-container {
     ion-select {
@@ -20,7 +20,7 @@
   .login-methods {
     display: flex;
     flex-direction: column;
-    gap: 1.5rem;
+    gap: 0.5rem;
     ion-button {
       ion-icon {
         margin-right: 0.5rem;

--- a/src/onboarding/OnboardingUpper/OnboardingUpper.scss
+++ b/src/onboarding/OnboardingUpper/OnboardingUpper.scss
@@ -10,16 +10,16 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 1rem;
+    gap: 0.5rem;
 
     h1 {
       color: #1d3557;
-      font-size: 2rem;
+      font-size: 1.7rem;
       font-weight: 700;
     }
 
     img {
-      height: 8rem;
+      height: 6rem;
       width: auto;
     }
   }

--- a/src/scanning/scanningHooks.js
+++ b/src/scanning/scanningHooks.js
@@ -10,6 +10,7 @@ import { useUserInfo } from "../common/hooks.js";
  * @param {import("../common/constants").SavedStatus} props.savedStatus
  * @param {string} props.groupIDs
  * @param {number} props.numPerPage
+ * @param {string|null} [props.queryID=null]
  * @returns {import("@tanstack/react-query").UseInfiniteQueryResult<import("@tanstack/react-query").InfiniteData<import("./scanningRequests.js").CandidateSearchResponse, unknown>, Error>}
  */
 export const useSearchCandidates = ({
@@ -18,6 +19,7 @@ export const useSearchCandidates = ({
   savedStatus,
   groupIDs,
   numPerPage,
+  queryID = null,
 }) => {
   const { userInfo } = useUserInfo();
   return useInfiniteQuery({
@@ -41,6 +43,7 @@ export const useSearchCandidates = ({
         groupIDs,
         numPerPage,
         pageNumber: ctx.pageParam ?? "1",
+        queryID,
       });
     },
     initialPageParam: 1,

--- a/src/scanning/scanningLib.js
+++ b/src/scanning/scanningLib.js
@@ -80,6 +80,13 @@
  * @property {number} numPerPage
  */
 
+/**
+ * @typedef {Object} ScanningRecap
+ * @property {string} queryId
+ * @property {Candidate[]} assigned
+ * @property {Candidate[]} notAssigned
+ */
+
 import { Clipboard } from "@capacitor/clipboard";
 import { useIonToast } from "@ionic/react";
 import { useCallback } from "react";

--- a/src/scanning/scanningLib.js
+++ b/src/scanning/scanningLib.js
@@ -83,6 +83,7 @@
 /**
  * @typedef {Object} ScanningRecap
  * @property {string} queryId
+ * @property {number} totalMatches
  * @property {Candidate[]} assigned
  * @property {Candidate[]} notAssigned
  */

--- a/src/scanning/scanningOptions/ScanningOptionsForm/ScanningOptionsForm.jsx
+++ b/src/scanning/scanningOptions/ScanningOptionsForm/ScanningOptionsForm.jsx
@@ -96,6 +96,7 @@ export const ScanningOptionsForm = () => {
         discardBehavior: data.discardBehavior,
         discardGroup: data.discardGroup,
       },
+      replace: true,
     });
   };
 

--- a/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
+++ b/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
@@ -48,6 +48,7 @@ export const CandidateScanner = () => {
     queryId: "",
     assigned: [],
     notAssigned: [],
+    totalMatches: 0,
   });
 
   const { userAccessibleGroups } = useUserAccessibleGroups();
@@ -102,6 +103,7 @@ export const CandidateScanner = () => {
   }
   queryID.current = data?.pages[0].queryID ?? null;
   scanningRecap.current.queryId = queryID.current ?? "";
+  scanningRecap.current.totalMatches = totalMatches ?? 0;
 
   const selectCallback = useCallback(
     (/** @type {import("embla-carousel").EmblaCarouselType} */ e) => {

--- a/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
+++ b/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
@@ -28,7 +28,7 @@ import { getPreference } from "../../../common/preferences.js";
 import { QUERY_KEYS } from "../../../common/constants.js";
 import { useMutation } from "@tanstack/react-query";
 import { parseIntList } from "../../scanningLib.js";
-import { ScanningRecap } from "../ScanningRecap/ScanningRecap.jsx";
+import { ScanningEnd } from "../ScanningEnd/ScanningEnd.jsx";
 
 export const CandidateScanner = () => {
   const numPerPage = 25;
@@ -42,9 +42,9 @@ export const CandidateScanner = () => {
 
   const [isLastBatch, setIsLastBatch] = useState(false);
 
-  /** @type {[import("../../scanningLib").ScanningRecap, React.Dispatch<import("../../scanningLib").ScanningRecap>]} */
+  /** @type {React.MutableRefObject<import("../../scanningLib").ScanningRecap>} */
   // @ts-ignore
-  const [scanningRecap, setScanningRecap] = useState({
+  const scanningRecap = useRef({
     queryId: "",
     assigned: [],
     notAssigned: [],
@@ -101,6 +101,7 @@ export const CandidateScanner = () => {
     setIsLastBatch(true);
   }
   queryID.current = data?.pages[0].queryID ?? null;
+  scanningRecap.current.queryId = queryID.current ?? "";
 
   const selectCallback = useCallback(
     (/** @type {import("embla-carousel").EmblaCarouselType} */ e) => {
@@ -310,10 +311,10 @@ export const CandidateScanner = () => {
         groupIds: scanningConfig.saveGroupIds,
       });
     }
-    setScanningRecap({
-      ...scanningRecap,
-      notAssigned: [...scanningRecap.notAssigned, currentCandidate],
-    });
+    scanningRecap.current = {
+      ...scanningRecap.current,
+      notAssigned: [...scanningRecap.current.notAssigned, currentCandidate],
+    };
   }, [currentCandidate, scanningConfig]);
 
   return (
@@ -338,7 +339,7 @@ export const CandidateScanner = () => {
           )}
           {isLastBatch && (
             <div className="embla__slide">
-              <ScanningRecap recap={scanningRecap} />
+              <ScanningEnd recap={scanningRecap} />
             </div>
           )}
         </div>

--- a/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
+++ b/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
@@ -83,11 +83,14 @@ export const CandidateScanner = () => {
 
   const isDiscardingEnabled = scanningConfig.junkGroups?.length ?? 0 > 0;
 
+  /** @type {React.MutableRefObject<string|null>} */
+  const queryID = useRef(null);
   const { data, fetchNextPage, isFetchingNextPage } = useSearchCandidates({
     startDate: queryParams.startDate,
     endDate: queryParams.endDate,
     savedStatus: queryParams.savedStatus,
     groupIDs: queryParams.groupIDs,
+    queryID: queryID.current,
     numPerPage,
   });
 
@@ -97,6 +100,7 @@ export const CandidateScanner = () => {
   if (candidates && candidates.length === totalMatches && !isLastBatch) {
     setIsLastBatch(true);
   }
+  queryID.current = data?.pages[0].queryID ?? null;
 
   const selectCallback = useCallback(
     (/** @type {import("embla-carousel").EmblaCarouselType} */ e) => {

--- a/src/scanning/scanningSession/ScanningCard/ScanningCard.scss
+++ b/src/scanning/scanningSession/ScanningCard/ScanningCard.scss
@@ -48,7 +48,7 @@
     flex-wrap: wrap;
     justify-content: space-between;
     height: fit-content;
-    row-gap: 0.3rem;
+    row-gap: 0.2rem;
   }
 
   .plot-container {

--- a/src/scanning/scanningSession/ScanningEnd/ScanningEnd.jsx
+++ b/src/scanning/scanningSession/ScanningEnd/ScanningEnd.jsx
@@ -1,0 +1,24 @@
+import "./ScanningEnd.scss";
+import { IonButton } from "@ionic/react";
+import { useHistory } from "react-router";
+
+/**
+ * @param {Object} props
+ * @param {React.MutableRefObject<import("../../scanningLib").ScanningRecap>} props.recap
+ * @returns {JSX.Element}
+ */
+export const ScanningEnd = ({ recap }) => {
+  const history = useHistory();
+  const handleButtonClick = () => {
+    history.replace("/scanning/recap", { recap: recap.current });
+  };
+  return (
+    <div className="scanning-end">
+      <h3 className="hint">You reached the end of the candidate list!</h3>
+
+      <IonButton expand="block" shape="round" onClick={handleButtonClick}>
+        Show recap
+      </IonButton>
+    </div>
+  );
+};

--- a/src/scanning/scanningSession/ScanningEnd/ScanningEnd.scss
+++ b/src/scanning/scanningSession/ScanningEnd/ScanningEnd.scss
@@ -1,0 +1,13 @@
+.scanning-end {
+  display: flex;
+  flex: 1;
+  height: 100%;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 10rem 1rem 1rem;
+  gap: 3rem;
+
+  .hint {
+    text-align: center;
+  }
+}

--- a/src/scanning/scanningSession/ScanningRecap/ScanningRecap.jsx
+++ b/src/scanning/scanningSession/ScanningRecap/ScanningRecap.jsx
@@ -1,0 +1,25 @@
+import { IonItem, IonList } from "@ionic/react";
+
+/**
+ * @param {Object} props
+ * @param {React.MutableRefObject<import("../../scanningLib").ScanningRecap>} props.recap
+ * @returns {JSX.Element}
+ */
+export const ScanningRecap = ({ recap }) => {
+  return (
+    <div>
+      <h1>Saved sources</h1>
+      <IonList>
+        {recap.current.assigned.length > 0 ? (
+          recap.current.assigned.map((source) => (
+            <IonItem key={source.id}>
+              <h2>{source.id}</h2>
+            </IonItem>
+          ))
+        ) : (
+          <p>No saved sources</p>
+        )}
+      </IonList>
+    </div>
+  );
+};

--- a/src/scanning/scanningSession/ScanningRecap/ScanningRecap.jsx
+++ b/src/scanning/scanningSession/ScanningRecap/ScanningRecap.jsx
@@ -1,25 +1,39 @@
-import { IonItem, IonList } from "@ionic/react";
+import "./ScanningRecap.scss";
+import { IonButton, IonItem, IonLabel, IonList } from "@ionic/react";
 
 /**
  * @param {Object} props
- * @param {React.MutableRefObject<import("../../scanningLib").ScanningRecap>} props.recap
+ * @param {import("../../scanningLib").ScanningRecap} props.recap
  * @returns {JSX.Element}
  */
 export const ScanningRecap = ({ recap }) => {
   return (
-    <div>
+    <div className="scanning-recap ion-padding">
       <h1>Saved sources</h1>
-      <IonList>
-        {recap.current.assigned.length > 0 ? (
-          recap.current.assigned.map((source) => (
-            <IonItem key={source.id}>
-              <h2>{source.id}</h2>
-            </IonItem>
-          ))
+      <div className="not-assigned">
+        <h5>Not assigned</h5>
+        {recap.notAssigned.length > 0 ? (
+          <>
+            <IonList>
+              {recap.notAssigned.map((source) => (
+                <IonItem key={source.id}>
+                  <IonLabel>{source.id}</IonLabel>
+                </IonItem>
+              ))}
+            </IonList>
+          </>
         ) : (
-          <p>No saved sources</p>
+          <p>You did not save any source</p>
         )}
-      </IonList>
+      </div>
+      {recap.notAssigned.length > 0 && (
+        <div className="button-container">
+          <IonButton expand="block">Draft email</IonButton>
+          <IonButton expand="block" fill="outline">
+            Exit
+          </IonButton>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/scanning/scanningSession/ScanningRecap/ScanningRecap.jsx
+++ b/src/scanning/scanningSession/ScanningRecap/ScanningRecap.jsx
@@ -8,24 +8,36 @@ import {
   IonLabel,
   IonList,
   IonPage,
-  IonRouterLink,
   IonTitle,
   IonToolbar,
 } from "@ionic/react";
 import moment from "moment-timezone";
 import { useUserInfo } from "../../../common/hooks.js";
 import { useCallback } from "react";
-import { useLocation } from "react-router";
-import { exitOutline, mailOutline } from "ionicons/icons";
+import { useHistory, useLocation } from "react-router";
+import { exitOutline, linkOutline, mailOutline } from "ionicons/icons";
 
 export const ScanningRecap = () => {
   const { userInfo } = useUserInfo();
   const location = useLocation();
+  const history = useHistory();
   /**
    * @type {import("../../scanningLib").ScanningRecap|undefined}
    */
   // @ts-ignore
   const recap = location.state?.recap;
+
+  const getLink = useCallback(
+    /**
+     * @param {import("../../scanningLib").Candidate} source
+     * @returns {string}
+     */
+    (source) => {
+      if (!userInfo) return "";
+      return userInfo.instance.url + `/source/${source.id}`;
+    },
+    [userInfo],
+  );
 
   const handleDraftEmail = useCallback(() => {
     if (!userInfo || !recap) {
@@ -38,9 +50,7 @@ export const ScanningRecap = () => {
     
     Saved, not assigned:
     `;
-    body += recap.notAssigned
-      .map((source) => userInfo.instance.url + `/source/${source.id}`)
-      .join("\n\n");
+    body += recap.notAssigned.map(getLink).join("\n\n");
     const bodyEncoded = encodeURIComponent(body);
     const subject = "Candidate scanning " + moment().format("YYYY-MM-DD");
     const subjectEncoded = encodeURIComponent(subject);
@@ -62,8 +72,18 @@ export const ScanningRecap = () => {
                 <h5>Not assigned</h5>
                 <IonList>
                   {(recap?.notAssigned ?? []).map((source) => (
-                    <IonItem key={source.id}>
+                    <IonItem
+                      key={source.id}
+                      onClick={() => window.open(getLink(source))}
+                      detail={false}
+                      button
+                    >
                       <IonLabel>{source.id}</IonLabel>
+                      <IonIcon
+                        slot="end"
+                        icon={linkOutline}
+                        color="primary"
+                      ></IonIcon>
                     </IonItem>
                   ))}
                 </IonList>
@@ -83,12 +103,15 @@ export const ScanningRecap = () => {
               </IonButton>
             </a>
           )}
-          <IonRouterLink routerLink="/app/scanning">
-            <IonButton expand="block" fill="outline" color="danger">
-              <IonIcon slot="start" icon={exitOutline}></IonIcon>
-              Exit
-            </IonButton>
-          </IonRouterLink>
+          <IonButton
+            expand="block"
+            fill="outline"
+            color="danger"
+            onClick={() => history.replace("/app/scanning")}
+          >
+            <IonIcon slot="start" icon={exitOutline}></IonIcon>
+            Exit
+          </IonButton>
         </div>
       </IonContent>
     </IonPage>

--- a/src/scanning/scanningSession/ScanningRecap/ScanningRecap.jsx
+++ b/src/scanning/scanningSession/ScanningRecap/ScanningRecap.jsx
@@ -1,24 +1,34 @@
 import "./ScanningRecap.scss";
 import {
   IonButton,
+  IonContent,
+  IonHeader,
+  IonIcon,
   IonItem,
   IonLabel,
   IonList,
+  IonPage,
   IonRouterLink,
+  IonTitle,
+  IonToolbar,
 } from "@ionic/react";
 import moment from "moment-timezone";
 import { useUserInfo } from "../../../common/hooks.js";
 import { useCallback } from "react";
+import { useLocation } from "react-router";
+import { exitOutline } from "ionicons/icons";
 
-/**
- * @param {Object} props
- * @param {import("../../scanningLib").ScanningRecap} props.recap
- * @returns {JSX.Element}
- */
-export const ScanningRecap = ({ recap }) => {
+export const ScanningRecap = () => {
   const { userInfo } = useUserInfo();
+  const location = useLocation();
+  /**
+   * @type {import("../../scanningLib").ScanningRecap|undefined}
+   */
+  // @ts-ignore
+  const recap = location.state?.recap;
+
   const handleDraftEmail = useCallback(() => {
-    if (!userInfo) {
+    if (!userInfo || !recap) {
       return;
     }
     const body = recap.notAssigned
@@ -28,38 +38,49 @@ export const ScanningRecap = ({ recap }) => {
     const subject = "Candidate scanning " + moment().format("YYYY-MM-DD");
     const subjectEncoded = encodeURIComponent(subject);
     return `mailto:?subject=${subjectEncoded}&body=${bodyEncoded}`;
-  }, [recap.notAssigned, userInfo]);
+  }, [recap?.notAssigned, userInfo]);
+
   return (
-    <div className="scanning-recap ion-padding">
-      <h1>Saved sources</h1>
-      <div className="not-assigned">
-        <h5>Not assigned</h5>
-        {recap.notAssigned.length > 0 ? (
-          <>
-            <IonList>
-              {recap.notAssigned.map((source) => (
-                <IonItem key={source.id}>
-                  <IonLabel>{source.id}</IonLabel>
-                </IonItem>
-              ))}
-            </IonList>
-          </>
-        ) : (
-          <p>You did not save any source</p>
-        )}
-      </div>
-      {recap.notAssigned.length > 0 && (
-        <div className="button-container">
-          <a href={handleDraftEmail()}>
-            <IonButton expand="block">Draft email</IonButton>
-          </a>
+    <IonPage className="scanning-recap">
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Scanning recap</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent className="ion-padding">
+        <div className="recap-container">
+          <div className="not-assigned">
+            {recap?.notAssigned?.length ?? 0 > 0 ? (
+              <>
+                <h5>Not assigned</h5>
+                <IonList>
+                  {(recap?.notAssigned ?? []).map((source) => (
+                    <IonItem key={source.id}>
+                      <IonLabel>{source.id}</IonLabel>
+                    </IonItem>
+                  ))}
+                </IonList>
+              </>
+            ) : (
+              <p style={{ textAlign: "center" }}>
+                You did not save any sources
+              </p>
+            )}
+          </div>
+
+          {(recap?.notAssigned?.length ?? 0) > 0 && (
+            <a href={handleDraftEmail()}>
+              <IonButton expand="block">Draft email</IonButton>
+            </a>
+          )}
           <IonRouterLink routerLink="/app/scanning">
-            <IonButton expand="block" fill="outline">
+            <IonButton expand="block" fill="outline" color="danger">
+              <IonIcon slot="start" icon={exitOutline}></IonIcon>
               Exit
             </IonButton>
           </IonRouterLink>
         </div>
-      )}
-    </div>
+      </IonContent>
+    </IonPage>
   );
 };

--- a/src/scanning/scanningSession/ScanningRecap/ScanningRecap.jsx
+++ b/src/scanning/scanningSession/ScanningRecap/ScanningRecap.jsx
@@ -1,5 +1,14 @@
 import "./ScanningRecap.scss";
-import { IonButton, IonItem, IonLabel, IonList } from "@ionic/react";
+import {
+  IonButton,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonRouterLink,
+} from "@ionic/react";
+import moment from "moment-timezone";
+import { useUserInfo } from "../../../common/hooks.js";
+import { useCallback } from "react";
 
 /**
  * @param {Object} props
@@ -7,6 +16,19 @@ import { IonButton, IonItem, IonLabel, IonList } from "@ionic/react";
  * @returns {JSX.Element}
  */
 export const ScanningRecap = ({ recap }) => {
+  const { userInfo } = useUserInfo();
+  const handleDraftEmail = useCallback(() => {
+    if (!userInfo) {
+      return;
+    }
+    const body = recap.notAssigned
+      .map((source) => userInfo.instance.url + `/source/${source.id}`)
+      .join("\n");
+    const bodyEncoded = encodeURIComponent(body);
+    const subject = "Candidate scanning " + moment().format("YYYY-MM-DD");
+    const subjectEncoded = encodeURIComponent(subject);
+    return `mailto:?subject=${subjectEncoded}&body=${bodyEncoded}`;
+  }, [recap.notAssigned, userInfo]);
   return (
     <div className="scanning-recap ion-padding">
       <h1>Saved sources</h1>
@@ -28,10 +50,14 @@ export const ScanningRecap = ({ recap }) => {
       </div>
       {recap.notAssigned.length > 0 && (
         <div className="button-container">
-          <IonButton expand="block">Draft email</IonButton>
-          <IonButton expand="block" fill="outline">
-            Exit
-          </IonButton>
+          <a href={handleDraftEmail()}>
+            <IonButton expand="block">Draft email</IonButton>
+          </a>
+          <IonRouterLink routerLink="/app/scanning">
+            <IonButton expand="block" fill="outline">
+              Exit
+            </IonButton>
+          </IonRouterLink>
         </div>
       )}
     </div>

--- a/src/scanning/scanningSession/ScanningRecap/ScanningRecap.jsx
+++ b/src/scanning/scanningSession/ScanningRecap/ScanningRecap.jsx
@@ -16,7 +16,7 @@ import moment from "moment-timezone";
 import { useUserInfo } from "../../../common/hooks.js";
 import { useCallback } from "react";
 import { useLocation } from "react-router";
-import { exitOutline } from "ionicons/icons";
+import { exitOutline, mailOutline } from "ionicons/icons";
 
 export const ScanningRecap = () => {
   const { userInfo } = useUserInfo();
@@ -77,7 +77,10 @@ export const ScanningRecap = () => {
 
           {(recap?.notAssigned?.length ?? 0) > 0 && (
             <a href={handleDraftEmail()}>
-              <IonButton expand="block">Draft email</IonButton>
+              <IonButton expand="block">
+                <IonIcon slot="start" icon={mailOutline}></IonIcon>
+                Draft email
+              </IonButton>
             </a>
           )}
           <IonRouterLink routerLink="/app/scanning">

--- a/src/scanning/scanningSession/ScanningRecap/ScanningRecap.jsx
+++ b/src/scanning/scanningSession/ScanningRecap/ScanningRecap.jsx
@@ -31,9 +31,16 @@ export const ScanningRecap = () => {
     if (!userInfo || !recap) {
       return;
     }
-    const body = recap.notAssigned
+    let body = `Dear all,
+    
+    ${recap.totalMatches} candidates
+    
+    
+    Saved, not assigned:
+    `;
+    body += recap.notAssigned
       .map((source) => userInfo.instance.url + `/source/${source.id}`)
-      .join("\n");
+      .join("\n\n");
     const bodyEncoded = encodeURIComponent(body);
     const subject = "Candidate scanning " + moment().format("YYYY-MM-DD");
     const subjectEncoded = encodeURIComponent(subject);

--- a/src/scanning/scanningSession/ScanningRecap/ScanningRecap.scss
+++ b/src/scanning/scanningSession/ScanningRecap/ScanningRecap.scss
@@ -1,18 +1,15 @@
 .scanning-recap {
-  display: grid;
-  grid-template-rows: auto 1fr auto;
-  grid-template-columns: 1fr;
-  flex: 1;
-  justify-content: flex-start;
-  h1 {
-    margin-bottom: 2rem;
-  }
-  h5 {
-    margin-bottom: 0.5rem;
-  }
-  .button-container {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
+  .recap-container {
+    display: grid;
+    grid-template-rows: 3fr auto auto;
+    grid-template-columns: 1fr;
+    flex: 1;
+    justify-content: flex-start;
+    height: 100%;
+    padding-bottom: var(--ion-safe-area-bottom);
+
+    h5 {
+      margin-bottom: 0.5rem;
+    }
   }
 }

--- a/src/scanning/scanningSession/ScanningRecap/ScanningRecap.scss
+++ b/src/scanning/scanningSession/ScanningRecap/ScanningRecap.scss
@@ -1,0 +1,18 @@
+.scanning-recap {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  grid-template-columns: 1fr;
+  flex: 1;
+  justify-content: flex-start;
+  h1 {
+    margin-bottom: 2rem;
+  }
+  h5 {
+    margin-bottom: 0.5rem;
+  }
+  .button-container {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+}

--- a/src/scanning/scanningSession/Thumbnail/Thumbnail.scss
+++ b/src/scanning/scanningSession/Thumbnail/Thumbnail.scss
@@ -4,7 +4,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: 30%;
+  width: 32%;
 
   .thumbnail-name {
     font-size: 0.6rem;


### PR DESCRIPTION
This adds a last card at the end of the candidate list to inform the user that they have reached the end and take them to a new recap page. The recap page shows the saved sources. Currently, only the "not assigned" sources are listed as users can't assign sources on the mobile application yet.

<img width="300" src="https://github.com/user-attachments/assets/33ca9e56-5cd4-4e54-9e92-791824607bfd" />


---

* New ScanningRecap.jsx component
* Make Thumbnails a little bit bigger and reduce space between the two rows
* Refactor the callbacks in CandidateScanner.jsx
* Can open mail client from screen recap