### PR TITLE
Display alert in the scanning form when no candidates are found

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -48,3 +48,5 @@ export const SAVED_STATUS = {
   NOT_SAVED_TO_ANY_SELECTED: "notSavedToAnySelected",
   NOT_SAVED_TO_ALL_SELECTED: "notSavedToAllSelected",
 };
+
+export const CANDIDATES_PER_PAGE = 50;

--- a/src/scanning/scanningLib.js
+++ b/src/scanning/scanningLib.js
@@ -78,6 +78,7 @@
  * @property {number[]} junkGroupIds
  * @property {Group[]} junkGroups
  * @property {number} numPerPage
+ * @property {string} queryID
  */
 
 /**
@@ -91,6 +92,9 @@
 import { Clipboard } from "@capacitor/clipboard";
 import { useIonToast } from "@ionic/react";
 import { useCallback } from "react";
+import { getPreference } from "../common/preferences.js";
+import { QUERY_KEYS } from "../common/constants.js";
+import { searchCandidates } from "./scanningRequests.js";
 
 /**
  * @type {Object<ThumbnailType, ThumbnailType>}
@@ -428,3 +432,32 @@ export const parseIntList = (intListString) =>
     .split(",")
     .filter((/** @type {string} **/ id) => id !== "")
     .map((/** @type {string} **/ id) => parseInt(id));
+
+/**
+ * @param {Object} params
+ * @param {string} params.groupIDs
+ * @param {import("../common/constants").SavedStatus} params.savedStatus
+ * @param {string} params.startDate
+ * @param {string} params.endDate
+ * @param {number} params.pageNumber
+ * @returns {Promise<import("./scanningRequests.js").CandidateSearchResponse>}
+ */
+export const initialSearchRequest = async ({
+  groupIDs,
+  savedStatus,
+  startDate,
+  endDate,
+  pageNumber,
+}) => {
+  /** @type {import("../onboarding/auth.js").UserInfo} */
+  const userInfo = await getPreference({ key: QUERY_KEYS.USER_INFO });
+  return searchCandidates({
+    instanceUrl: userInfo.instance.url,
+    token: userInfo.token,
+    groupIDs,
+    savedStatus,
+    startDate,
+    endDate,
+    pageNumber,
+  });
+};

--- a/src/scanning/scanningRequests.js
+++ b/src/scanning/scanningRequests.js
@@ -1,4 +1,5 @@
 import { CapacitorHttp } from "@capacitor/core";
+import { CANDIDATES_PER_PAGE } from "../common/constants.js";
 
 /**
  * @typedef {Object} CandidateSearchResponse
@@ -19,7 +20,7 @@ import { CapacitorHttp } from "@capacitor/core";
  * @param {string} params.groupIDs - The group IDs to search for
  * @param {string|null} [params.queryID=null] - The query ID
  * @param {number} params.pageNumber - The page number
- * @param {number} params.numPerPage - The number of candidates per page
+ * @param {number} [params.numPerPage] - The number of candidates per page
  * @returns {Promise<CandidateSearchResponse>}
  */
 export async function searchCandidates({
@@ -31,7 +32,7 @@ export async function searchCandidates({
   groupIDs,
   queryID = null,
   pageNumber,
-  numPerPage,
+  numPerPage = CANDIDATES_PER_PAGE,
 }) {
   // example: https://preview.fritz.science/api/candidates?pageNumber=1&numPerPage=50&groupIDs=4&savedStatus=savedToAnySelected&listNameReject=rejected_candidates&startDate=2024-07-01T21%3A27%3A27.232Z
   let response = await CapacitorHttp.get({

--- a/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
+++ b/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
@@ -77,6 +77,7 @@ export const CandidateScanner = () => {
           .filter((g) => g !== undefined)
       : [],
     numPerPage,
+    queryID: queryParams.queryID,
   };
 
   const [presentToast] = useIonToast();
@@ -84,14 +85,12 @@ export const CandidateScanner = () => {
 
   const isDiscardingEnabled = scanningConfig.junkGroups?.length ?? 0 > 0;
 
-  /** @type {React.MutableRefObject<string|null>} */
-  const queryID = useRef(null);
   const { data, fetchNextPage, isFetchingNextPage } = useSearchCandidates({
     startDate: queryParams.startDate,
     endDate: queryParams.endDate,
     savedStatus: queryParams.savedStatus,
     groupIDs: queryParams.groupIDs,
-    queryID: queryID.current,
+    queryID: queryParams.queryID,
     numPerPage,
   });
 
@@ -101,8 +100,7 @@ export const CandidateScanner = () => {
   if (candidates && candidates.length === totalMatches && !isLastBatch) {
     setIsLastBatch(true);
   }
-  queryID.current = data?.pages[0].queryID ?? null;
-  scanningRecap.current.queryId = queryID.current ?? "";
+  scanningRecap.current.queryId = scanningConfig.queryID ?? "";
   scanningRecap.current.totalMatches = totalMatches ?? 0;
 
   const selectCallback = useCallback(


### PR DESCRIPTION
This prevents navigating to the main scanning page when the search request does not give any results. The scanning form perform the search request a first time to check that there are candidates and then navigates to the main page if there are. If there are no candidates, an alert is displayed to the user, asking them to change the configuration.
<img width="300" src="https://github.com/user-attachments/assets/425a330f-cc79-4517-950c-93e354e2900d" />

---

* New constant `CANDIDATES_PER_PAGE`
* Add mutation to ScanningOptionsForm.jsx to fetch candidates and check if there are any before navigating