### PR TITLE
Remove detail indicators from annotation lines

### DIFF
--- a/src/scanning/scanningLib.js
+++ b/src/scanning/scanningLib.js
@@ -410,6 +410,9 @@ export const useCopyAnnotationLineOnClick = () => {
      * @param {string|number|undefined} value
      */
     async (key, value) => {
+      if (value === undefined) {
+        return;
+      }
       await Clipboard.write({
         string: `${key}: ${value}`,
       });

--- a/src/scanning/scanningSession/CandidateAnnotationItem/CandidateAnnotationItem.jsx
+++ b/src/scanning/scanningSession/CandidateAnnotationItem/CandidateAnnotationItem.jsx
@@ -24,6 +24,7 @@ export const CandidateAnnotationItem = ({ annotation }) => {
             <IonItem
               key={key}
               onClick={() => handleTextCopied(key, value)}
+              detail={false}
               button
             >
               {key}: {value}

--- a/src/scanning/scanningSession/CandidateAnnotationItem/CandidateAnnotationItem.jsx
+++ b/src/scanning/scanningSession/CandidateAnnotationItem/CandidateAnnotationItem.jsx
@@ -1,6 +1,14 @@
 import "./CandidateAnnotationItem.scss";
-import { IonItem, IonLabel, IonList, IonListHeader } from "@ionic/react";
+import {
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonListHeader,
+  IonText,
+} from "@ionic/react";
 import { useCopyAnnotationLineOnClick } from "../../scanningLib.js";
+import { copyOutline } from "ionicons/icons";
 
 /**
  * @param {Object} props
@@ -27,7 +35,13 @@ export const CandidateAnnotationItem = ({ annotation }) => {
               detail={false}
               button
             >
-              {key}: {value}
+              <IonText color="secondary">{key}:</IonText>
+              {"\u00A0"}
+              <IonText>{value}</IonText>
+              {"\u00A0"}
+              {"\u00A0"}
+              {"\u00A0"}
+              <IonIcon icon={copyOutline} size="small" color="secondary" />
             </IonItem>
           ))}
       </IonList>

--- a/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.jsx
+++ b/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.jsx
@@ -40,6 +40,7 @@ export const PinnedAnnotations = ({
             onClick={() =>
               handleTextCopied(annotationLine.id, annotationLine.value)
             }
+            detail={false}
             button
           >
             <IonText className="name" color="secondary">

--- a/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.jsx
+++ b/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.jsx
@@ -1,6 +1,7 @@
 import "./PinnedAnnotations.scss";
-import { IonButton, IonItem, IonText } from "@ionic/react";
+import { IonButton, IonIcon, IonItem, IonText } from "@ionic/react";
 import { useCopyAnnotationLineOnClick } from "../../scanningLib.js";
+import { copyOutline } from "ionicons/icons";
 
 /**
  * @param {Object} props
@@ -47,7 +48,21 @@ export const PinnedAnnotations = ({
               {annotationLine.id}:
             </IonText>
             {"\u00A0"}
-            <div>{annotationLine.value}</div>
+            {annotationLine.value ? (
+              <div>
+                {annotationLine.value}
+                {"\u00A0"}
+                {"\u00A0"}
+                {"\u00A0"}
+                <IonIcon icon={copyOutline} size="small" color="secondary" />
+              </div>
+            ) : (
+              <>
+                <IonText color="warning" className="no-value">
+                  No value
+                </IonText>
+              </>
+            )}
           </IonItem>
         ))}
       </div>

--- a/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.scss
+++ b/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.scss
@@ -13,12 +13,11 @@
     flex-direction: column;
     justify-content: space-around;
     flex: 1;
-    gap: 0.1rem;
 
     ion-item {
       --background: none;
-      --inner-padding-bottom: 0;
-      --inner-padding-top: 0;
+      --inner-padding-bottom: 0.2rem;
+      --inner-padding-top: 0.1rem;
       --padding-start: 0.2rem;
       --min-height: 0;
     }


### PR DESCRIPTION
This removes navigation indicators from annotation lines in both the pinned annotations panel and the annotation list. It also adds indicators for the case when a pinned annotation value is missing. Finally, it adds icons to nudge the user to copy annotation values by tapping the annotation lines in the pinned annotations panel or the list.

<img width="300" src="https://github.com/user-attachments/assets/7473a4ce-4a3c-4f42-9c8b-3fe2dd5b7496" />
<img width="300" src="https://github.com/user-attachments/assets/a106e6fc-aa44-4533-8479-68d5517e2fe7" />


---

* Remove detail indicators from annotation lines
* Indicate when there is no value for an annotation key in the PinnedAnnotations.jsx panel
* Add an icon to nudge the user into copying an annotation value in both the pinned annotations and the annotation list