### PR TITLE
Add a toolbar to the scanning screen

### DIFF
--- a/src/scanning/scanningLib.js
+++ b/src/scanning/scanningLib.js
@@ -439,11 +439,16 @@ export const useCopyAnnotationLineOnClick = () => {
  * @param {string} intListString
  * @returns {number[]}
  */
-export const parseIntList = (intListString) =>
-  intListString
-    .split(",")
-    .filter((/** @type {string} **/ id) => id !== "")
-    .map((/** @type {string} **/ id) => parseInt(id));
+export const parseIntList = (intListString) => {
+  try {
+    return intListString
+      .split(",")
+      .filter((/** @type {string} **/ id) => id !== "")
+      .map((/** @type {string} **/ id) => parseInt(id));
+  } catch (e) {
+    return [];
+  }
+};
 
 /**
  * @param {Object} params
@@ -475,18 +480,18 @@ export const initialSearchRequest = async ({
 };
 
 /**
- * @typedef {"MORE"|"REQUEST_OBSERVING_RUN"|"REQUEST_FOLLOW_UP"|"ADD_REDSHIFT"|"SHOW_SURVEYS"|"SAVE"|"DISCARD"} ScanningToolbarAction
+ * @typedef {"REQUEST_OBSERVING_RUN"|"REQUEST_FOLLOW_UP"|"ADD_REDSHIFT"|"SHOW_SURVEYS"|"SAVE"|"DISCARD"|"EXIT"} ScanningToolbarAction
  */
 
 /**
  * @type {Object<ScanningToolbarAction, ScanningToolbarAction>}
  */
 export const SCANNING_TOOLBAR_ACTION = {
-  MORE: "MORE",
   REQUEST_FOLLOW_UP: "REQUEST_FOLLOW_UP",
   REQUEST_OBSERVING_RUN: "REQUEST_OBSERVING_RUN",
   ADD_REDSHIFT: "ADD_REDSHIFT",
   SHOW_SURVEYS: "SHOW_SURVEYS",
   SAVE: "SAVE",
   DISCARD: "DISCARD",
+  EXIT: "EXIT",
 };

--- a/src/scanning/scanningLib.js
+++ b/src/scanning/scanningLib.js
@@ -473,3 +473,20 @@ export const initialSearchRequest = async ({
     pageNumber,
   });
 };
+
+/**
+ * @typedef {"MORE"|"REQUEST_OBSERVING_RUN"|"REQUEST_FOLLOW_UP"|"ADD_REDSHIFT"|"SHOW_SURVEYS"|"SAVE"|"DISCARD"} ScanningToolbarAction
+ */
+
+/**
+ * @type {Object<ScanningToolbarAction, ScanningToolbarAction>}
+ */
+export const SCANNING_TOOLBAR_ACTION = {
+  MORE: "MORE",
+  REQUEST_FOLLOW_UP: "REQUEST_FOLLOW_UP",
+  REQUEST_OBSERVING_RUN: "REQUEST_OBSERVING_RUN",
+  ADD_REDSHIFT: "ADD_REDSHIFT",
+  SHOW_SURVEYS: "SHOW_SURVEYS",
+  SAVE: "SAVE",
+  DISCARD: "DISCARD",
+};

--- a/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
+++ b/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
@@ -1,23 +1,11 @@
 import "./CandidateScanner.scss";
-import {
-  IonButton,
-  IonIcon,
-  IonModal,
-  useIonAlert,
-  useIonToast,
-} from "@ionic/react";
+import { IonModal, useIonAlert, useIonToast } from "@ionic/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   useQueryParams,
   useUserAccessibleGroups,
 } from "../../../common/hooks.js";
-import {
-  arrowForward,
-  checkmark,
-  checkmarkCircleOutline,
-  trashBin,
-  warningOutline,
-} from "ionicons/icons";
+import { checkmarkCircleOutline, warningOutline } from "ionicons/icons";
 import useEmblaCarousel from "embla-carousel-react";
 import { CandidateAnnotationsViewer } from "../CandidateAnnotationsViewer/CandidateAnnotationsViewer.jsx";
 import { ScanningCard } from "../ScanningCard/ScanningCard.jsx";
@@ -27,8 +15,9 @@ import { addSourceToGroup } from "../../scanningRequests.js";
 import { getPreference } from "../../../common/preferences.js";
 import { QUERY_KEYS } from "../../../common/constants.js";
 import { useMutation } from "@tanstack/react-query";
-import { parseIntList } from "../../scanningLib.js";
+import { parseIntList, SCANNING_TOOLBAR_ACTION } from "../../scanningLib.js";
 import { ScanningEnd } from "../ScanningEnd/ScanningEnd.jsx";
+import { ScanningToolbar } from "../ScanningToolbar/ScanningToolbar.jsx";
 
 export const CandidateScanner = () => {
   const numPerPage = 25;
@@ -317,6 +306,30 @@ export const CandidateScanner = () => {
     };
   }, [currentCandidate, scanningConfig]);
 
+  /**
+   * @param {import("../../scanningLib.js").ScanningToolbarAction} action
+   */
+  const handleToolbarAction = async (action) => {
+    switch (action) {
+      case SCANNING_TOOLBAR_ACTION.MORE:
+        break;
+      case SCANNING_TOOLBAR_ACTION.REQUEST_OBSERVING_RUN:
+        break;
+      case SCANNING_TOOLBAR_ACTION.REQUEST_FOLLOW_UP:
+        break;
+      case SCANNING_TOOLBAR_ACTION.ADD_REDSHIFT:
+        break;
+      case SCANNING_TOOLBAR_ACTION.SHOW_SURVEYS:
+        break;
+      case SCANNING_TOOLBAR_ACTION.SAVE:
+        await handleSave();
+        break;
+      case SCANNING_TOOLBAR_ACTION.DISCARD:
+        await handleDiscard();
+        break;
+    }
+  };
+
   return (
     <div className="candidate-scanner">
       <div className="embla" ref={emblaRef}>
@@ -345,36 +358,7 @@ export const CandidateScanner = () => {
         </div>
       </div>
       {currentIndex < (totalMatches ?? 99999999) && (
-        <div className="action-buttons-container">
-          <IonButton
-            onClick={() => handleDiscard()}
-            shape="round"
-            size="large"
-            color="danger"
-            fill="outline"
-            disabled={!isDiscardingEnabled}
-          >
-            <IonIcon icon={trashBin} slot="icon-only" />
-          </IonButton>
-          <IonButton
-            onClick={() => handleSave()}
-            shape="round"
-            size="large"
-            color="success"
-            fill="outline"
-          >
-            <IonIcon icon={checkmark} slot="icon-only" />
-          </IonButton>
-          <IonButton
-            shape="round"
-            size="large"
-            color="secondary"
-            fill="outline"
-            onClick={() => emblaApi?.scrollNext()}
-          >
-            <IonIcon icon={arrowForward} slot="icon-only" />
-          </IonButton>
-        </div>
+        <ScanningToolbar onAction={handleToolbarAction} />
       )}
 
       <IonModal

--- a/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
+++ b/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
@@ -310,8 +310,10 @@ export const CandidateScanner = () => {
    * @param {import("../../scanningLib.js").ScanningToolbarAction} action
    */
   const handleToolbarAction = async (action) => {
+    console.log("action", action);
     switch (action) {
-      case SCANNING_TOOLBAR_ACTION.MORE:
+      case SCANNING_TOOLBAR_ACTION.EXIT:
+        history.back();
         break;
       case SCANNING_TOOLBAR_ACTION.REQUEST_OBSERVING_RUN:
         break;

--- a/src/scanning/scanningSession/ScanningToolbar/ScanningToolbar.jsx
+++ b/src/scanning/scanningSession/ScanningToolbar/ScanningToolbar.jsx
@@ -32,7 +32,11 @@ export const ScanningToolbar = ({ onAction }) => {
   const [present, dismiss] = useIonPopover(
     <IonContent>
       <IonList>
-        <IonItem detail={false} button>
+        <IonItem
+          detail={false}
+          onClick={() => onAction(SCANNING_TOOLBAR_ACTION.EXIT)}
+          button
+        >
           <IonIcon
             color="danger"
             slot="start"
@@ -64,6 +68,7 @@ export const ScanningToolbar = ({ onAction }) => {
               // @ts-ignore
               event: e,
               onWillDismiss: () => setIsMenuOpen(false),
+              dismissOnSelect: true,
             })
           }
         >

--- a/src/scanning/scanningSession/ScanningToolbar/ScanningToolbar.jsx
+++ b/src/scanning/scanningSession/ScanningToolbar/ScanningToolbar.jsx
@@ -1,0 +1,109 @@
+import "./ScanningToolbar.scss";
+import {
+  IonButton,
+  IonContent,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  useIonPopover,
+} from "@ionic/react";
+import {
+  bookmarkOutline,
+  ellipsisHorizontal,
+  ellipsisHorizontalOutline,
+  exitOutline,
+  locateOutline,
+  planetOutline,
+  telescopeOutline,
+  trashBinOutline,
+} from "ionicons/icons";
+import { SCANNING_TOOLBAR_ACTION } from "../../scanningLib.js";
+import { useState } from "react";
+
+/**
+ * @param {Object} props
+ * @param {(action: import("../../scanningLib").ScanningToolbarAction) => void} props.onAction
+ * @returns {JSX.Element}
+ */
+export const ScanningToolbar = ({ onAction }) => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const [present, dismiss] = useIonPopover(
+    <IonContent>
+      <IonList>
+        <IonItem detail={false} button>
+          <IonIcon
+            color="danger"
+            slot="start"
+            icon={exitOutline}
+            size="small"
+          />
+          <IonLabel color="danger">Exit</IonLabel>
+        </IonItem>
+        <IonItem detail={false} button>
+          <IonIcon slot="start" icon={trashBinOutline} size="small" />
+          <IonLabel>Discard</IonLabel>
+        </IonItem>
+      </IonList>
+    </IonContent>,
+    {
+      onDismiss: (/** @type {any} */ data, /** @type {string} */ role) =>
+        dismiss(data, role),
+    },
+  );
+
+  return (
+    <>
+      <div className="scanning-toolbar">
+        <IonButton
+          fill="clear"
+          color="secondary"
+          onClick={(e) =>
+            present({
+              // @ts-ignore
+              event: e,
+              onWillDismiss: () => setIsMenuOpen(false),
+            })
+          }
+        >
+          <IonIcon
+            slot="icon-only"
+            icon={isMenuOpen ? ellipsisHorizontal : ellipsisHorizontalOutline}
+          />
+        </IonButton>
+
+        <IonButton
+          fill="clear"
+          color="secondary"
+          onClick={() =>
+            onAction(SCANNING_TOOLBAR_ACTION.REQUEST_OBSERVING_RUN)
+          }
+        >
+          <IonIcon slot="icon-only" icon={telescopeOutline} />
+        </IonButton>
+        <IonButton
+          fill="clear"
+          color="secondary"
+          onClick={() => onAction(SCANNING_TOOLBAR_ACTION.ADD_REDSHIFT)}
+        >
+          <IonIcon slot="icon-only" icon={locateOutline} />
+        </IonButton>
+        <IonButton fill="clear" color="secondary">
+          <IonIcon
+            slot="icon-only"
+            icon={planetOutline}
+            onClick={() => onAction(SCANNING_TOOLBAR_ACTION.SHOW_SURVEYS)}
+          />
+        </IonButton>
+        <IonButton fill="clear" color="success">
+          <IonIcon
+            slot="icon-only"
+            icon={bookmarkOutline}
+            onClick={() => onAction(SCANNING_TOOLBAR_ACTION.SAVE)}
+          />
+        </IonButton>
+      </div>
+    </>
+  );
+};

--- a/src/scanning/scanningSession/ScanningToolbar/ScanningToolbar.jsx
+++ b/src/scanning/scanningSession/ScanningToolbar/ScanningToolbar.jsx
@@ -24,9 +24,10 @@ import { useState } from "react";
 /**
  * @param {Object} props
  * @param {(action: import("../../scanningLib").ScanningToolbarAction) => void} props.onAction
+ * @param {boolean} props.isDiscardingEnabled
  * @returns {JSX.Element}
  */
-export const ScanningToolbar = ({ onAction }) => {
+export const ScanningToolbar = ({ onAction, isDiscardingEnabled }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const [present, dismiss] = useIonPopover(
@@ -45,7 +46,11 @@ export const ScanningToolbar = ({ onAction }) => {
           />
           <IonLabel color="danger">Exit</IonLabel>
         </IonItem>
-        <IonItem detail={false} button>
+        <IonItem
+          detail={false}
+          onClick={() => onAction(SCANNING_TOOLBAR_ACTION.DISCARD)}
+          button
+        >
           <IonIcon slot="start" icon={trashBinOutline} size="small" />
           <IonLabel>Discard</IonLabel>
         </IonItem>
@@ -60,23 +65,35 @@ export const ScanningToolbar = ({ onAction }) => {
   return (
     <>
       <div className="scanning-toolbar">
-        <IonButton
-          fill="clear"
-          color="secondary"
-          onClick={(e) =>
-            present({
-              // @ts-ignore
-              event: e,
-              onWillDismiss: () => setIsMenuOpen(false),
-              dismissOnSelect: true,
-            })
-          }
-        >
-          <IonIcon
-            slot="icon-only"
-            icon={isMenuOpen ? ellipsisHorizontal : ellipsisHorizontalOutline}
-          />
-        </IonButton>
+        {isDiscardingEnabled && (
+          <IonButton
+            fill="clear"
+            color="secondary"
+            onClick={(e) =>
+              present({
+                // @ts-ignore
+                event: e,
+                onWillDismiss: () => setIsMenuOpen(false),
+                dismissOnSelect: true,
+              })
+            }
+          >
+            <IonIcon
+              slot="icon-only"
+              icon={isMenuOpen ? ellipsisHorizontal : ellipsisHorizontalOutline}
+            />
+          </IonButton>
+        )}
+
+        {!isDiscardingEnabled && (
+          <IonButton
+            fill="clear"
+            color="danger"
+            onClick={() => onAction(SCANNING_TOOLBAR_ACTION.EXIT)}
+          >
+            <IonIcon slot="icon-only" icon={exitOutline} />
+          </IonButton>
+        )}
 
         <IonButton
           fill="clear"

--- a/src/scanning/scanningSession/ScanningToolbar/ScanningToolbar.scss
+++ b/src/scanning/scanningSession/ScanningToolbar/ScanningToolbar.scss
@@ -1,0 +1,12 @@
+.scanning-toolbar {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  background: #ffffff;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 1.5rem;
+  margin: 0.7rem 0.4rem 0;
+  border-radius: 1rem;
+  border: 1px solid #c1c7ce;
+  contain: layout;
+}


### PR DESCRIPTION
This replaces the buttons at the bottom of the scanning screen by a toolbar with multiple actions. Currently the only implemented actions are:
* `SAVE`
* `DISCARD`
* `EXIT`

But other could be implemented afterwards like requesting a follow up or an observing run, adding a redshift value, showing a survey page...

<img width="300" src="https://github.com/user-attachments/assets/b9d6c550-638c-4500-8e71-43013cce737d" />


---

* New ScanningToolbar.jsx component
* New `ScanningToolbarAction` type with a new `SCANNING_TOOLBAR_ACTION` constant
* Add alert before exiting
* Make `parseIntList` function safe