### PR TITLE
Enforce color theme

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,7 +33,7 @@ import "@ionic/react/css/display.css";
  */
 /* import '@ionic/react/css/palettes/dark.always.css'; */
 /* import '@ionic/react/css/palettes/dark.class.css'; */
-// import '@ionic/react/css/palettes/dark.system.css';
+import "@ionic/react/css/palettes/dark.system.css";
 /* Theme variables */
 import "./theme/variables.scss";
 import { IonReactRouter } from "@ionic/react-router";

--- a/src/scanning/scanningLib.js
+++ b/src/scanning/scanningLib.js
@@ -201,6 +201,9 @@ export const getVegaPlotSpec = ({
     colorScale.domain.push(f);
     colorScale.range.push(`rgb(${bandpassesColors[f].join(",")})`);
   });
+  const isDarkMode =
+    window.matchMedia &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches;
   const mjdNow = Date.now() / 86400000.0 + 40587.0;
   return /** @type {any} */ ({
     $schema: "https://vega.github.io/schema/vega-lite/v5.2.0.json",
@@ -262,6 +265,8 @@ export const getVegaPlotSpec = ({
               title: "mag",
               titleFontSize,
               labelFontSize,
+              titleColor: isDarkMode ? "white" : "black",
+              labelColor: isDarkMode ? "white" : "black",
             },
           },
           color: {
@@ -319,6 +324,8 @@ export const getVegaPlotSpec = ({
               title: "days ago",
               titleFontSize,
               labelFontSize,
+              titleColor: isDarkMode ? "white" : "black",
+              labelColor: isDarkMode ? "white" : "black",
             },
           },
           y: {
@@ -344,6 +351,8 @@ export const getVegaPlotSpec = ({
               orient: "bottom",
               titleFontSize,
               labelFontSize,
+              titleColor: isDarkMode ? "white" : "black",
+              labelColor: isDarkMode ? "white" : "black",
             },
           },
           opacity: {

--- a/src/scanning/scanningOptions/ScanningOptionsDate/ScanningOptionsDate.jsx
+++ b/src/scanning/scanningOptions/ScanningOptionsDate/ScanningOptionsDate.jsx
@@ -24,11 +24,11 @@ export const ScanningOptionsDate = ({ getValues, control, errors }) => {
 
   return (
     <>
-      <IonList inset lines="full">
+      <IonList inset lines="full" color="light">
         <IonListHeader>
           <IonLabel>Dates (local time)</IonLabel>
         </IonListHeader>
-        <IonItem>
+        <IonItem color="light">
           <IonLabel>Start date:</IonLabel>
           <IonDatetimeButton datetime="datetime-start"></IonDatetimeButton>
         </IonItem>

--- a/src/scanning/scanningOptions/ScanningOptionsForm/ScanningOptionsForm.scss
+++ b/src/scanning/scanningOptions/ScanningOptionsForm/ScanningOptionsForm.scss
@@ -31,6 +31,7 @@
   width: 100%;
   height: auto;
   box-shadow: 1px -1px 5px 0 rgba(var(--ion-color-medium-rgb), 0.25);
+  background: var(--ion-color-light);
 
   ion-button {
     --padding-start: 4rem;

--- a/src/scanning/scanningOptions/ScanningOptionsForm/ScanningOptionsForm.scss
+++ b/src/scanning/scanningOptions/ScanningOptionsForm/ScanningOptionsForm.scss
@@ -4,10 +4,10 @@
   overflow: scroll;
 
   ion-list {
-    background: white;
+    background: var(--ion-color-light);
 
     ion-item {
-      --background: white;
+      --background: var(--ion-color-light);
     }
 
     ion-list-header {
@@ -30,7 +30,7 @@
   z-index: 2;
   width: 100%;
   height: auto;
-  box-shadow: 1px -1px 5px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: 1px -1px 5px 0 rgba(var(--ion-color-medium-rgb), 0.25);
 
   ion-button {
     --padding-start: 4rem;

--- a/src/scanning/scanningOptions/ScanningOptionsScreen/ScanningOptionsScreen.jsx
+++ b/src/scanning/scanningOptions/ScanningOptionsScreen/ScanningOptionsScreen.jsx
@@ -18,7 +18,7 @@ export const ScanningOptionsScreen = () => {
           <IonTitle>Scanning options</IonTitle>
         </IonToolbar>
       </IonHeader>
-      <IonContent color="light">
+      <IonContent>
         <Suspense
           fallback={
             <div className="scanning-option-loading">

--- a/src/scanning/scanningSession/CandidatePhotometryChart/CandidatePhotometryChart.scss
+++ b/src/scanning/scanningSession/CandidatePhotometryChart/CandidatePhotometryChart.scss
@@ -10,7 +10,7 @@
   .canvas-loading {
     display: flex;
     flex-direction: column;
-    background: #ffffff;
+    background: var(--ion-color-light);
     justify-content: center;
     align-items: center;
     z-index: 100;

--- a/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.scss
+++ b/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.scss
@@ -3,10 +3,10 @@
   justify-content: center;
   align-items: center;
   padding: 0.5rem;
-  border: 0.5px rgba(82, 100, 117, 0.3) solid;
+  border: 0.5px rgba(var(--ion-color-secondary-rgb), 0.3) solid;
   align-self: center;
   border-radius: 0.5rem;
-  box-shadow: 0 0 3px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0 3px rgba(var(--ion-color-medium-rgb), 0.2);
 
   .annotations {
     display: flex;

--- a/src/scanning/scanningSession/PinnedAnnotationsSkeleton/PinnedAnnotationsSkeleton.jsx
+++ b/src/scanning/scanningSession/PinnedAnnotationsSkeleton/PinnedAnnotationsSkeleton.jsx
@@ -13,7 +13,6 @@ export const PinnedAnnotationsSkeleton = ({ animated }) => {
         {[1, 2, 3].map((index) => (
           <div key={index} className="annotation-line">
             <IonSkeletonText
-              className="name"
               style={{ width: "2rem", height: ".8rem" }}
               animated={animated}
             />

--- a/src/scanning/scanningSession/ScanningCard/ScanningCard.scss
+++ b/src/scanning/scanningSession/ScanningCard/ScanningCard.scss
@@ -12,7 +12,7 @@
   padding: 0.5rem;
   margin: 0 0.4rem;
   border-radius: 1rem;
-  background-color: #ffffff;
+  background-color: var(--ion-color-light);
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 
   &.skeleton {

--- a/src/scanning/scanningSession/ScanningCard/ScanningCardSkeleton.jsx
+++ b/src/scanning/scanningSession/ScanningCard/ScanningCardSkeleton.jsx
@@ -18,10 +18,16 @@ export const ScanningCardSkeleton = ({ animated = false, visible = true }) => {
     >
       <div className="candidate-name">
         <h1>
-          <IonSkeletonText style={{ width: "8rem" }} animated={animated} />
+          <IonSkeletonText
+            style={{ width: "8rem", height: "1.2rem" }}
+            animated={animated}
+          />
         </h1>
         <div className="pagination-indicator">
-          <IonSkeletonText style={{ width: "2rem" }} animated={animated} />
+          <IonSkeletonText
+            style={{ width: "2rem", height: ".8rem" }}
+            animated={animated}
+          />
         </div>
       </div>
       <div className="thumbnails-container">

--- a/src/scanning/scanningSession/Thumbnail/Thumbnail.scss
+++ b/src/scanning/scanningSession/Thumbnail/Thumbnail.scss
@@ -26,6 +26,10 @@
       height: auto;
     }
 
+    .thumbnail-skeleton-img {
+      height: 100%;
+    }
+
     .crosshairs {
       position: absolute;
       top: 0;

--- a/src/sources/SourceListItem/SourceListItem.scss
+++ b/src/sources/SourceListItem/SourceListItem.scss
@@ -5,7 +5,7 @@
   align-items: flex-start;
   padding: 0.75rem 1rem;
   border-radius: 1rem;
-  background-color: white;
+  background-color: var(--ion-color-light);
   gap: 0.5rem;
 
   .header {
@@ -22,12 +22,12 @@
         font-weight: 500;
       }
       .tns-name {
-        color: #717983;
+        color: var(--ion-color-secondary);
       }
     }
 
     .icon {
-      color: #a9adb1;
+      color: var(--ion-color-primary);
       font-size: 1.2rem;
     }
   }
@@ -39,7 +39,7 @@
     font-size: 0.75rem;
 
     .label {
-      color: #717983;
+      color: var(--ion-color-secondary);
     }
   }
   .coords {

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -24,70 +24,139 @@ ion-skeleton-text {
 }
 
 :root {
-  --ion-color-primary: #457b9d;
-  --ion-color-primary-rgb: 69, 123, 157;
+  --ion-color-primary: #195676;
+  --ion-color-primary-rgb: 25, 86, 118;
   --ion-color-primary-contrast: #ffffff;
   --ion-color-primary-contrast-rgb: 255, 255, 255;
-  --ion-color-primary-shade: #3d6c8a;
-  --ion-color-primary-tint: #5888a7;
+  --ion-color-primary-shade: #164c68;
+  --ion-color-primary-tint: #306784;
 
-  --ion-color-secondary: #526475;
-  --ion-color-secondary-rgb: 82, 100, 117;
+  --ion-color-secondary: #4e616f;
+  --ion-color-secondary-rgb: 78, 97, 111;
   --ion-color-secondary-contrast: #ffffff;
   --ion-color-secondary-contrast-rgb: 255, 255, 255;
-  --ion-color-secondary-shade: #485867;
-  --ion-color-secondary-tint: #637483;
+  --ion-color-secondary-shade: #455562;
+  --ion-color-secondary-tint: #60717d;
 
-  --ion-color-tertiary: #1d3557;
-  --ion-color-tertiary-rgb: 29, 53, 87;
+  --ion-color-tertiary: #356668;
+  --ion-color-tertiary-rgb: 53, 102, 104;
   --ion-color-tertiary-contrast: #ffffff;
   --ion-color-tertiary-contrast-rgb: 255, 255, 255;
-  --ion-color-tertiary-shade: #1a2f4d;
-  --ion-color-tertiary-tint: #344968;
+  --ion-color-tertiary-shade: #2f5a5c;
+  --ion-color-tertiary-tint: #497577;
 
-  --ion-color-success: #438e29;
-  --ion-color-success-rgb: 67, 142, 41;
+  --ion-color-success: #195d00;
+  --ion-color-success-rgb: 25, 93, 0;
   --ion-color-success-contrast: #ffffff;
-  --ion-color-success-contrast-rgb: 0, 0, 0;
+  --ion-color-success-contrast-rgb: 255, 255, 255;
   --ion-color-success-shade: #3b7d24;
   --ion-color-success-tint: #56993e;
 
-  --ion-color-warning: #ee9d2b;
-  --ion-color-warning-rgb: 238, 157, 43;
-  --ion-color-warning-contrast: #000000;
-  --ion-color-warning-contrast-rgb: 0, 0, 0;
-  --ion-color-warning-shade: #d18a26;
-  --ion-color-warning-tint: #f0a740;
+  --ion-color-warning: #785a00;
+  --ion-color-warning-rgb: 120, 90, 0;
+  --ion-color-warning-contrast: #ffffff;
+  --ion-color-warning-contrast-rgb: 255, 255, 255;
+  --ion-color-warning-shade: #6a4f00;
+  --ion-color-warning-tint: #866b1a;
 
-  --ion-color-danger: #e63946;
-  --ion-color-danger-rgb: 230, 57, 70;
-  --ion-color-danger-contrast: #000000;
-  --ion-color-danger-contrast-rgb: 0, 0, 0;
-  --ion-color-danger-shade: #ca323e;
-  --ion-color-danger-tint: #e94d59;
+  --ion-color-danger: #97000a;
+  --ion-color-danger-rgb: 151, 0, 10;
+  --ion-color-danger-contrast: #ffffff;
+  --ion-color-danger-contrast-rgb: 255, 255, 255;
+  --ion-color-danger-shade: #850009;
+  --ion-color-danger-tint: #a11a23;
 
-  --ion-color-light: #f7faff;
-  --ion-color-light-rgb: 247, 250, 255;
-  --ion-color-light-contrast: var(--ion-color-secondary);
-  --ion-color-light-contrast-rgb: 0, 0, 0;
-  --ion-color-light-shade: #d9dce0;
-  --ion-color-light-tint: #f8fbff;
+  --ion-color-light: #f8f9fc;
+  --ion-color-light-rgb: 248, 249, 252;
+  --ion-color-light-contrast: #191c1e;
+  --ion-color-light-contrast-rgb: 25, 28, 30;
+  --ion-color-light-shade: #dadbde;
+  --ion-color-light-tint: #f9fafc;
 
-  --ion-color-medium: #526475;
-  --ion-color-medium-rgb: 82, 100, 117;
+  --ion-color-medium: #5f5f5f;
+  --ion-color-medium-rgb: 95, 95, 95;
   --ion-color-medium-contrast: #ffffff;
   --ion-color-medium-contrast-rgb: 255, 255, 255;
-  --ion-color-medium-shade: #485867;
-  --ion-color-medium-tint: #637483;
+  --ion-color-medium-shade: #545454;
+  --ion-color-medium-tint: #6f6f6f;
 
-  --ion-color-dark: #383d46;
-  --ion-color-dark-rgb: 56, 61, 70;
+  --ion-color-dark: #2f2f2f;
+  --ion-color-dark-rgb: 47, 47, 47;
   --ion-color-dark-contrast: #ffffff;
   --ion-color-dark-contrast-rgb: 255, 255, 255;
-  --ion-color-dark-shade: #31363e;
-  --ion-color-dark-tint: #4c5059;
+  --ion-color-dark-shade: #292929;
+  --ion-color-dark-tint: #444444;
 
-  --ion-background-color: #f4f4fa;
+  --ion-background-color: #ebf3fa;
 
   --ion-font-family: "Roboto", sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ion-color-primary: #98cdf2;
+    --ion-color-primary-rgb: 152, 205, 242;
+    --ion-color-primary-contrast: #00344c;
+    --ion-color-primary-contrast-rgb: 0, 52, 76;
+    --ion-color-primary-shade: #86b4d5;
+    --ion-color-primary-tint: #a2d2f3;
+
+    --ion-color-secondary: #b5c9d9;
+    --ion-color-secondary-rgb: 181, 201, 217;
+    --ion-color-secondary-contrast: #20333f;
+    --ion-color-secondary-contrast-rgb: 32, 51, 63;
+    --ion-color-secondary-shade: #9fb1bf;
+    --ion-color-secondary-tint: #bccedd;
+
+    --ion-color-tertiary: #d7feff;
+    --ion-color-tertiary-rgb: 215, 254, 255;
+    --ion-color-tertiary-contrast: #003739;
+    --ion-color-tertiary-contrast-rgb: 0, 55, 57;
+    --ion-color-tertiary-shade: #bde0e0;
+    --ion-color-tertiary-tint: #dbfeff;
+
+    --ion-color-success: #69dd8f;
+    --ion-color-success-rgb: 105, 221, 143;
+    --ion-color-success-contrast: #00391a;
+    --ion-color-success-contrast-rgb: 0, 57, 26;
+    --ion-color-success-shade: #5cc27e;
+    --ion-color-success-tint: #78e09a;
+
+    --ion-color-warning: #d0a53b;
+    --ion-color-warning-rgb: 208, 165, 59;
+    --ion-color-warning-contrast: #3f2e00;
+    --ion-color-warning-contrast-rgb: 63, 46, 0;
+    --ion-color-warning-shade: #b79134;
+    --ion-color-warning-tint: #d5ae4f;
+
+    --ion-color-danger: #ffb4ab;
+    --ion-color-danger-rgb: 255, 180, 171;
+    --ion-color-danger-contrast: #690004;
+    --ion-color-danger-contrast-rgb: 105, 0, 4;
+    --ion-color-danger-shade: #e09e96;
+    --ion-color-danger-tint: #ffbcb3;
+
+    --ion-color-light: #111416;
+    --ion-color-light-rgb: 17, 20, 22;
+    --ion-color-light-contrast: #e1e2e5;
+    --ion-color-light-contrast-rgb: 225, 226, 229;
+    --ion-color-light-shade: #0f1213;
+    --ion-color-light-tint: #292c2d;
+
+    //--ion-color-medium: #5f5f5f;
+    //--ion-color-medium-rgb: 95, 95, 95;
+    //--ion-color-medium-contrast: #ffffff;
+    //--ion-color-medium-contrast-rgb: 255, 255, 255;
+    //--ion-color-medium-shade: #545454;
+    //--ion-color-medium-tint: #6f6f6f;
+    //
+    //--ion-color-dark: #2f2f2f;
+    //--ion-color-dark-rgb: 47, 47, 47;
+    //--ion-color-dark-contrast: #ffffff;
+    //--ion-color-dark-contrast-rgb: 255, 255, 255;
+    //--ion-color-dark-shade: #292929;
+    //--ion-color-dark-tint: #444444;
+
+    --ion-background-color: #2f2f2f;
+  }
 }


### PR DESCRIPTION
This ensures that only the colors from the ionic theme are being used in the application. The theme colors have been updated using values generated by the [Material Theme Builder plugin](https://www.figma.com/community/plugin/1034969338659738588/material-theme-builder) on Figma. Dark theme has also been enabled so users with dark mode enabled at system level will be able to have the application in dark mode.


<img width="300" src="https://github.com/user-attachments/assets/621b912d-32ae-4c39-a93e-1831deee94fa" />
<img width="300" src="https://github.com/user-attachments/assets/477ce411-91ee-4b33-b061-7900f3012059" />

---

* Change background color of scanning options screen footer
* Fix the ScanningCardSkeleton appearance
* Use theme colors in PinnedAnnotations.scss
* Use theme colors in SourceListItem.scss
* Update theme colors using Material Theme Builder
* Enable dark theme and fix colors in ScanningCard.scss and CandidatePhotometryChart.scss