### PR TITLE
Select pinned annotations and small refactoring of CandidateScanner

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -31,6 +31,7 @@ export const QUERY_KEYS = {
   APP_START: "appStart",
   BANDPASS_COLORS: "bandpassColors",
   SCANNING_PROFILES: "scanningProfiles",
+  ANNOTATIONS_INFO: "annotationsInfo",
 };
 
 /**

--- a/src/common/hooks.js
+++ b/src/common/hooks.js
@@ -14,6 +14,8 @@ import config from "../config.js";
 import { fetchUserProfile } from "../onboarding/auth.js";
 import { fetchConfig } from "./requests.js";
 import { fetchGroups } from "../scanning/scanningRequests.js";
+import { useContext } from "react";
+import { UserContext } from "./context.js";
 
 /**
  * @typedef {"success" | "error" | "pending"} QueryStatus
@@ -141,10 +143,10 @@ export const useAppStart = () => {
 };
 
 /**
- * @param {import("../onboarding/auth.js").UserInfo} userInfo
  * @returns {{userAccessibleGroups: import("../scanning/scanningLib.js").Group[]|undefined, status: QueryStatus, error: any|undefined}}
  */
-export const useUserAccessibleGroups = (userInfo) => {
+export const useUserAccessibleGroups = () => {
+  const userInfo = useContext(UserContext);
   const {
     /** @type {import("../scanning/scanningLib.js").GroupsResponse} */ data: groups,
     status,
@@ -158,19 +160,6 @@ export const useUserAccessibleGroups = (userInfo) => {
     status,
     error,
   };
-};
-
-/**
- * @returns {{[key: string]: any}}
- */
-export const useQueryParams = () => {
-  const params = new URLSearchParams(location.search);
-  const paramsObject = {};
-  for (const [key, value] of params) {
-    // @ts-ignore
-    paramsObject[key] = value;
-  }
-  return paramsObject;
 };
 
 /**

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -4,14 +4,16 @@
  * @param {string} path
  * @param {Object} options
  * @param {Record<string, string>} [options.params]
+ * @param {any} [options.state]
  * @param {boolean} [options.replace]
  */
 export const navigateWithParams = (
   history,
   path,
-  { params, replace = false },
+  { params, state, replace = false },
 ) => {
   history[replace ? "replace" : "push"](
     `${path}?${new URLSearchParams(params).toString()}`,
+    state,
   );
 };

--- a/src/scanning/scanningHooks.js
+++ b/src/scanning/scanningHooks.js
@@ -1,7 +1,9 @@
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { QUERY_KEYS } from "../common/constants.js";
-import { searchCandidates } from "./scanningRequests.js";
+import { fetchAnnotationInfo, searchCandidates } from "./scanningRequests.js";
 import { fetchUserProfile } from "../onboarding/auth.js";
+import { useContext } from "react";
+import { UserContext } from "../common/context.js";
 
 /**
  * @param {Object} props
@@ -74,6 +76,26 @@ export const useScanningProfiles = (userInfo) => {
   });
   return {
     profiles,
+    status,
+    error,
+  };
+};
+
+/**
+ * @returns {{annotationsInfo: import("./scanningRequests.js").AnnotationsInfo | undefined, status: import("@tanstack/react-query").QueryStatus, error: any | undefined }}
+ */
+export const useAnnotationsInfo = () => {
+  const userInfo = useContext(UserContext);
+  const {
+    data: annotationsInfo,
+    status,
+    error,
+  } = useQuery({
+    queryKey: [QUERY_KEYS.ANNOTATIONS_INFO],
+    queryFn: () => fetchAnnotationInfo({ userInfo }),
+  });
+  return {
+    annotationsInfo,
     status,
     error,
   };

--- a/src/scanning/scanningHooks.js
+++ b/src/scanning/scanningHooks.js
@@ -1,30 +1,37 @@
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
-import { QUERY_KEYS } from "../common/constants.js";
+import { CANDIDATES_PER_PAGE, QUERY_KEYS } from "../common/constants.js";
 import { fetchAnnotationInfo, searchCandidates } from "./scanningRequests.js";
 import { fetchUserProfile } from "../onboarding/auth.js";
 import { useContext } from "react";
 import { UserContext } from "../common/context.js";
+import { useLocation } from "react-router";
 
 /**
- * @param {Object} props
- * @param {string} props.startDate
- * @param {string|null} [props.endDate=null]
- * @param {import("../common/constants").SavedStatus} props.savedStatus
- * @param {string} props.groupIDs
- * @param {number} props.numPerPage
- * @param {string|null} [props.queryID=null]
- * @param {import("../onboarding/auth.js").UserInfo} props.userInfo
  * @returns {import("@tanstack/react-query").UseInfiniteQueryResult<import("@tanstack/react-query").InfiniteData<import("./scanningRequests.js").CandidateSearchResponse, unknown>, Error>}
  */
-export const useSearchCandidates = ({
-  startDate,
-  endDate = null,
-  savedStatus,
-  groupIDs,
-  numPerPage,
-  queryID = null,
-  userInfo,
-}) => {
+export const useSearchCandidates = () => {
+  const userInfo = useContext(UserContext);
+  /** @type {any} */
+  const { state } = useLocation();
+  /** @type {string} */
+  let startDate = "";
+  /** @type {string} */
+  let endDate = "";
+  /** @type {import("../common/constants.js").SavedStatus} */
+  let savedStatus = "all";
+  /** @type {number[]} */
+  let groupIDs = [];
+  /** @type {string} */
+  let queryID = "";
+
+  if (state) {
+    startDate = state.startDate;
+    endDate = state.endDate;
+    savedStatus = state.savedStatus;
+    groupIDs = state.saveGroupIds;
+    queryID = state.queryID;
+  }
+
   return useInfiniteQuery({
     queryKey: [
       QUERY_KEYS.CANDIDATES,
@@ -43,18 +50,18 @@ export const useSearchCandidates = ({
         endDate,
         savedStatus,
         groupIDs,
-        numPerPage,
         pageNumber: ctx.pageParam ?? "1",
         queryID,
       });
     },
     initialPageParam: 1,
     getNextPageParam: (lastPage) => {
-      if (lastPage.candidates.length < numPerPage) {
+      if (lastPage.candidates.length < CANDIDATES_PER_PAGE) {
         return undefined;
       }
       return +lastPage.pageNumber + 1;
     },
+    enabled: !!state,
   });
 };
 

--- a/src/scanning/scanningLib.js
+++ b/src/scanning/scanningLib.js
@@ -577,3 +577,14 @@ export const SCANNING_TOOLBAR_ACTION = {
  */
 export const getAnnotationId = (group, annotationKey) =>
   `${group}/${annotationKey}`;
+
+/**
+ * @param {string} annotationId
+ * @returns {{key: string, origin: string}}
+ */
+export const extractAnnotationOriginAndKey = (annotationId) => {
+  const lastIndexOfSlash = annotationId.lastIndexOf("/");
+  const origin = annotationId.slice(0, lastIndexOfSlash);
+  const key = annotationId.slice(lastIndexOfSlash + 1);
+  return { origin, key };
+};

--- a/src/scanning/scanningLib.js
+++ b/src/scanning/scanningLib.js
@@ -77,6 +77,7 @@
  * @property {Group[]} saveGroups
  * @property {number[]} junkGroupIds
  * @property {Group[]} junkGroups
+ * @property {string[]} pinnedAnnotations
  * @property {number} numPerPage
  * @property {string} queryID
  */

--- a/src/scanning/scanningLib.js
+++ b/src/scanning/scanningLib.js
@@ -75,11 +75,11 @@
  * @property {DiscardBehavior} discardBehavior
  * @property {number[]} saveGroupIds
  * @property {Group[]} saveGroups
- * @property {number[]} junkGroupIds
+ * @property {number[]} junkGroupIDs
  * @property {Group[]} junkGroups
  * @property {string[]} pinnedAnnotations
- * @property {number} numPerPage
  * @property {string} queryID
+ * @property {number} totalMatches
  */
 
 /**

--- a/src/scanning/scanningLib.js
+++ b/src/scanning/scanningLib.js
@@ -549,6 +549,7 @@ export const getDefaultValues = () => ({
   junkGroups: [],
   discardBehavior: "specific",
   discardGroup: null,
+  pinnedAnnotations: [],
 });
 
 /**

--- a/src/scanning/scanningLib.js
+++ b/src/scanning/scanningLib.js
@@ -568,3 +568,11 @@ export const SCANNING_TOOLBAR_ACTION = {
   DISCARD: "DISCARD",
   EXIT: "EXIT",
 };
+
+/**
+ * @param {string} group
+ * @param {string} annotationKey
+ * @returns {`${string}/${string}`}
+ */
+export const getAnnotationId = (group, annotationKey) =>
+  `${group}/${annotationKey}`;

--- a/src/scanning/scanningOptions/PinnedAnnotationsPicker/PinnedAnnotationsPicker.jsx
+++ b/src/scanning/scanningOptions/PinnedAnnotationsPicker/PinnedAnnotationsPicker.jsx
@@ -1,0 +1,119 @@
+import {
+  IonBadge,
+  IonButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonItem,
+  IonItemDivider,
+  IonItemGroup,
+  IonLabel,
+  IonTitle,
+  IonToolbar,
+} from "@ionic/react";
+import { useCallback, useState } from "react";
+
+/**
+ * @param {Object} props
+ * @param {import("../../scanningRequests").AnnotationsInfo} props.annotationsInfo
+ * @param {string[]} props.selectedAnnotationKeys
+ * @param {React.MutableRefObject<any>} props.modal
+ * @param {number} [props.limit=3]
+ * @param {(keys: string[]) => void} props.onDismiss
+ * @returns {JSX.Element}
+ */
+export const PinnedAnnotationsPicker = ({
+  annotationsInfo,
+  modal,
+  selectedAnnotationKeys,
+  limit = 3,
+  onDismiss,
+}) => {
+  const [localSelected, setLocalSelected] = useState(selectedAnnotationKeys);
+  const selectedIndex = useCallback(
+    /**
+     * @param {string} group
+     * @param {string} annotationKey
+     * @returns {number}
+     */
+    (group, annotationKey) =>
+      localSelected.findIndex((key) => key === `${group}:${annotationKey}`),
+    [localSelected],
+  );
+
+  const togglePinAnnotation = useCallback(
+    /**
+     * @param {string} group
+     * @param {string} annotationKey
+     */
+    (group, annotationKey) => {
+      const annotationId = `${group}:${annotationKey}`;
+      if (selectedIndex(group, annotationKey) !== -1) {
+        setLocalSelected((prev) =>
+          prev.filter((item) => item !== annotationId),
+        );
+      } else {
+        if (localSelected.length <= limit) {
+          setLocalSelected((prev) => [...prev, annotationId]);
+        }
+      }
+    },
+    [localSelected],
+  );
+
+  const onDone = () => {
+    onDismiss(localSelected);
+    modal.current?.dismiss();
+  };
+
+  return (
+    <>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            <IonButton onClick={() => modal.current?.dismiss()}>
+              Cancel
+            </IonButton>
+          </IonButtons>
+          <IonTitle>Select pinned annotations</IonTitle>
+          <IonButtons slot="end">
+            <IonButton onClick={onDone}>Done</IonButton>
+          </IonButtons>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent>
+        {Object.entries(annotationsInfo).map(([group, annotationInfoItem]) => (
+          <IonItemGroup key={group}>
+            <IonItemDivider>
+              <IonLabel>{group}</IonLabel>
+            </IonItemDivider>
+            {annotationInfoItem
+              // @ts-ignore
+              .map(
+                (
+                  /** @type {import("../../scanningRequests").AnnotationKeyInfo} */ annotationKeyInfo,
+                ) => {
+                  const annotationKey = Object.keys(annotationKeyInfo)[0];
+                  return (
+                    <IonItem
+                      key={annotationKey}
+                      onClick={() => togglePinAnnotation(group, annotationKey)}
+                      detail={false}
+                      button
+                    >
+                      <IonLabel>{annotationKey}</IonLabel>
+                      {selectedIndex(group, annotationKey) !== -1 && (
+                        <IonBadge>
+                          {selectedIndex(group, annotationKey) + 1}
+                        </IonBadge>
+                      )}
+                    </IonItem>
+                  );
+                },
+              )}
+          </IonItemGroup>
+        ))}
+      </IonContent>
+    </>
+  );
+};

--- a/src/scanning/scanningOptions/PinnedAnnotationsPicker/PinnedAnnotationsPicker.jsx
+++ b/src/scanning/scanningOptions/PinnedAnnotationsPicker/PinnedAnnotationsPicker.jsx
@@ -12,6 +12,7 @@ import {
   IonToolbar,
 } from "@ionic/react";
 import { useCallback, useState } from "react";
+import { getAnnotationId } from "../../scanningLib.js";
 
 /**
  * @param {Object} props
@@ -37,7 +38,9 @@ export const PinnedAnnotationsPicker = ({
      * @returns {number}
      */
     (group, annotationKey) =>
-      localSelected.findIndex((key) => key === `${group}:${annotationKey}`),
+      localSelected.findIndex(
+        (key) => key === getAnnotationId(group, annotationKey),
+      ),
     [localSelected],
   );
 
@@ -47,7 +50,7 @@ export const PinnedAnnotationsPicker = ({
      * @param {string} annotationKey
      */
     (group, annotationKey) => {
-      const annotationId = `${group}:${annotationKey}`;
+      const annotationId = getAnnotationId(group, annotationKey);
       if (selectedIndex(group, annotationKey) !== -1) {
         setLocalSelected((prev) =>
           prev.filter((item) => item !== annotationId),

--- a/src/scanning/scanningOptions/PinnedAnnotationsPicker/PinnedAnnotationsPicker.jsx
+++ b/src/scanning/scanningOptions/PinnedAnnotationsPicker/PinnedAnnotationsPicker.jsx
@@ -9,6 +9,7 @@ import {
   IonItemGroup,
   IonLabel,
   IonSearchbar,
+  IonText,
   IonTitle,
   IonToolbar,
 } from "@ionic/react";
@@ -123,6 +124,11 @@ export const PinnedAnnotationsPicker = ({
             onIonInput={onSearchQuery}
             debounce={300}
           ></IonSearchbar>
+        </IonToolbar>
+        <IonToolbar>
+          <IonText className="ion-padding">
+            {localSelected.length} selected
+          </IonText>
         </IonToolbar>
       </IonHeader>
       <IonContent>

--- a/src/scanning/scanningOptions/RecentProfiles/RecentProfiles.jsx
+++ b/src/scanning/scanningOptions/RecentProfiles/RecentProfiles.jsx
@@ -55,43 +55,45 @@ export const RecentProfiles = () => {
           <IonIcon icon={chevronForwardOutline} />
         </IonButton>
       </div>
-      {profiles && userAccessibleGroups && (
-        <div className="sp-content">
-          {profiles.length > 0 && defaultProfileIndex && (
-            <IonList color="light" inset>
-              <ProfileListItem
-                key={profiles[defaultProfileIndex].name}
-                profile={profiles[defaultProfileIndex]}
-                userAccessibleGroups={userAccessibleGroups}
-                onClick={() =>
-                  handleScanWithProfile(profiles[defaultProfileIndex])
-                }
-              />
-              {profiles
-                .toSpliced(defaultProfileIndex, 1)
-                .toSpliced(2)
-                .map((profile) => (
-                  <ProfileListItem
-                    key={profile.name}
-                    profile={profile}
-                    userAccessibleGroups={userAccessibleGroups}
-                    onClick={() => handleScanWithProfile(profile)}
-                  />
-                ))}
-            </IonList>
-          )}
-          {profiles.length === 0 && (
-            <div className="hint-container">
-              <IonText color="secondary" className="hint">
-                You don’t have any profiles yet. You can add a new one or click
-                the “Scan without a profile” button below to configure the
-                scanning session manually.
-              </IonText>
-            </div>
-          )}
-        </div>
-      )}
-      {!profiles || (!userAccessibleGroups && <IonLoading />)}
+      <div className="sp-content">
+        {profiles && userAccessibleGroups && (
+          <>
+            {profiles.length > 0 && defaultProfileIndex && (
+              <IonList color="light" inset>
+                <ProfileListItem
+                  key={profiles[defaultProfileIndex].name}
+                  profile={profiles[defaultProfileIndex]}
+                  userAccessibleGroups={userAccessibleGroups}
+                  onClick={() =>
+                    handleScanWithProfile(profiles[defaultProfileIndex])
+                  }
+                />
+                {profiles
+                  .toSpliced(defaultProfileIndex, 1)
+                  .toSpliced(2)
+                  .map((profile) => (
+                    <ProfileListItem
+                      key={profile.name}
+                      profile={profile}
+                      userAccessibleGroups={userAccessibleGroups}
+                      onClick={() => handleScanWithProfile(profile)}
+                    />
+                  ))}
+              </IonList>
+            )}
+            {profiles.length === 0 && (
+              <div className="hint-container">
+                <IonText color="secondary" className="hint">
+                  You don’t have any profiles yet. You can add a new one or
+                  click the “Scan without a profile” button below to configure
+                  the scanning session manually.
+                </IonText>
+              </div>
+            )}
+          </>
+        )}
+        {(!profiles || !userAccessibleGroups) && <IonLoading />}
+      </div>
       <div className="buttons-container">
         <IonButton
           shape="round"

--- a/src/scanning/scanningOptions/RecentProfiles/RecentProfiles.scss
+++ b/src/scanning/scanningOptions/RecentProfiles/RecentProfiles.scss
@@ -1,6 +1,6 @@
 .scanning-profiles {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
   height: 100%;
   padding-bottom: calc(55px + #{var(--ion-safe-area-bottom)} + 1rem);
 
@@ -12,11 +12,8 @@
   }
 
   .sp-content {
-    flex: 1;
-
     .hint-container {
       display: flex;
-      flex: 1;
       align-items: center;
       justify-content: center;
 
@@ -25,6 +22,7 @@
       }
     }
   }
+
   .buttons-container {
     display: flex;
     gap: 0.25rem;

--- a/src/scanning/scanningOptions/ScanningOptionsDiscarding/ScanningOptionsDiscarding.jsx
+++ b/src/scanning/scanningOptions/ScanningOptionsDiscarding/ScanningOptionsDiscarding.jsx
@@ -40,8 +40,6 @@ export const ScanningOptionsDiscarding = ({
   );
   return (
     <div className="form-section">
-      <IonLabel className="form-list-header">Junk</IonLabel>
-
       <IonList inset>
         <IonItem lines="none">
           <IonLabel>

--- a/src/scanning/scanningOptions/ScanningOptionsForm/ScanningOptionsForm.jsx
+++ b/src/scanning/scanningOptions/ScanningOptionsForm/ScanningOptionsForm.jsx
@@ -22,6 +22,7 @@ import {
   getFiltering,
   getStartDate,
 } from "../../scanningLib.js";
+import { ScanningOptionsPinnedAnnotations } from "../ScanningOptionsPinnedAnnotations/ScanningOptionsPinnedAnnotations.jsx";
 
 export const ScanningOptionsForm = () => {
   const userInfo = useContext(UserContext);
@@ -67,6 +68,7 @@ export const ScanningOptionsForm = () => {
      * @param {string} params.junkGroupIDs
      * @param {string} params.discardBehavior
      * @param {string} params.discardGroup
+     * @param {string} params.pinnedAnnotations
      * @returns {Promise<any>}
      */
     mutationFn: async ({
@@ -77,6 +79,7 @@ export const ScanningOptionsForm = () => {
       junkGroupIDs,
       discardBehavior,
       discardGroup,
+      pinnedAnnotations,
     }) => {
       const response = await searchCandidates({
         groupIDs,
@@ -98,6 +101,7 @@ export const ScanningOptionsForm = () => {
         junkGroupIDs,
         discardBehavior,
         discardGroup,
+        pinnedAnnotations,
         queryID: response.queryID,
       };
     },
@@ -144,6 +148,7 @@ export const ScanningOptionsForm = () => {
     const startDate = moment(data.startDate).format();
     const endDate = moment(data.endDate).format();
     const junkGroupIDs = data.junkGroups.join(",");
+    const pinnedAnnotations = data.pinnedAnnotations.join(",");
 
     searchCandidatesMutation.mutate({
       groupIDs,
@@ -151,6 +156,7 @@ export const ScanningOptionsForm = () => {
       startDate,
       endDate,
       junkGroupIDs,
+      pinnedAnnotations,
       discardBehavior: data.discardBehavior,
       discardGroup: data.discardGroup,
     });
@@ -160,6 +166,7 @@ export const ScanningOptionsForm = () => {
   const groupSelectionModal = useRef(null);
   /** @type {React.MutableRefObject<any>} */
   const junkGroupSelectionModal = useRef(null);
+  const pinnedAnnotationSelectionModal = useRef(null);
   const { userAccessibleGroups = [] } = useUserAccessibleGroups(userInfo);
 
   return (
@@ -189,6 +196,11 @@ export const ScanningOptionsForm = () => {
           watch={watch}
           modal={junkGroupSelectionModal}
           userAccessibleGroups={userAccessibleGroups}
+        />
+        <ScanningOptionsPinnedAnnotations
+          control={control}
+          watch={watch}
+          modal={pinnedAnnotationSelectionModal}
         />
       </form>
       <div className="form-footer">

--- a/src/scanning/scanningOptions/ScanningOptionsForm/ScanningOptionsForm.scss
+++ b/src/scanning/scanningOptions/ScanningOptionsForm/ScanningOptionsForm.scss
@@ -2,4 +2,5 @@
   width: 100%;
   flex: 1;
   overflow: scroll;
+  padding-top: 0.5rem;
 }

--- a/src/scanning/scanningOptions/ScanningOptionsPinnedAnnotations/ScanningOptionsPinnedAnnotations.jsx
+++ b/src/scanning/scanningOptions/ScanningOptionsPinnedAnnotations/ScanningOptionsPinnedAnnotations.jsx
@@ -1,0 +1,63 @@
+import {
+  IonButton,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonModal,
+} from "@ionic/react";
+import { useAnnotationsInfo } from "../../scanningHooks.js";
+import { pencil } from "ionicons/icons";
+import { PinnedAnnotationsPicker } from "../PinnedAnnotationsPicker/PinnedAnnotationsPicker.jsx";
+import { Controller } from "react-hook-form";
+
+/**
+ * @param {Object} props
+ * @param {import("react-hook-form").Control<any,any>} props.control
+ * @param {import("react-hook-form").UseFormWatch<any>} props.watch
+ * @param {React.MutableRefObject<any>} props.modal
+ * @returns {JSX.Element}
+ */
+export const ScanningOptionsPinnedAnnotations = ({ control, watch, modal }) => {
+  const { annotationsInfo } = useAnnotationsInfo();
+  /** @type {string[]} */
+  const pinnedAnnotations = watch("pinnedAnnotations");
+  return (
+    <div className="form-section">
+      <IonList lines="full" color="light" inset>
+        <IonItem>
+          <IonLabel>
+            Pinned annotations
+            <p>{pinnedAnnotations.length} selected (select up to 3)</p>
+          </IonLabel>
+          <IonButton id="select-pinned-annotations" fill="clear">
+            Edit<IonIcon slot="end" icon={pencil}></IonIcon>
+          </IonButton>
+        </IonItem>
+        {pinnedAnnotations.map((annotationKey) => (
+          <IonItem key={annotationKey}>{annotationKey}</IonItem>
+        ))}
+      </IonList>
+      {annotationsInfo && (
+        <IonModal
+          ref={modal}
+          trigger="select-pinned-annotations"
+          isOpen={false}
+        >
+          <Controller
+            name="pinnedAnnotations"
+            control={control}
+            render={({ field: { onChange, value } }) => (
+              <PinnedAnnotationsPicker
+                annotationsInfo={annotationsInfo}
+                modal={modal}
+                selectedAnnotationKeys={value}
+                onDismiss={onChange}
+              />
+            )}
+          />
+        </IonModal>
+      )}
+    </div>
+  );
+};

--- a/src/scanning/scanningOptions/ScanningOptionsPinnedAnnotations/ScanningOptionsPinnedAnnotations.jsx
+++ b/src/scanning/scanningOptions/ScanningOptionsPinnedAnnotations/ScanningOptionsPinnedAnnotations.jsx
@@ -10,6 +10,7 @@ import { useAnnotationsInfo } from "../../scanningHooks.js";
 import { pencil } from "ionicons/icons";
 import { PinnedAnnotationsPicker } from "../PinnedAnnotationsPicker/PinnedAnnotationsPicker.jsx";
 import { Controller } from "react-hook-form";
+import { extractAnnotationOriginAndKey } from "../../scanningLib.js";
 
 /**
  * @param {Object} props
@@ -34,9 +35,16 @@ export const ScanningOptionsPinnedAnnotations = ({ control, watch, modal }) => {
             Edit<IonIcon slot="end" icon={pencil}></IonIcon>
           </IonButton>
         </IonItem>
-        {pinnedAnnotations.map((annotationKey) => (
-          <IonItem key={annotationKey}>{annotationKey}</IonItem>
-        ))}
+        {pinnedAnnotations
+          .map((annotationKey) => extractAnnotationOriginAndKey(annotationKey))
+          .map(({ origin, key }) => (
+            <IonItem key={`${origin}${key}`}>
+              <IonLabel>
+                {key}
+                <p>{origin}</p>
+              </IonLabel>
+            </IonItem>
+          ))}
       </IonList>
       {annotationsInfo && (
         <IonModal

--- a/src/scanning/scanningRequests.js
+++ b/src/scanning/scanningRequests.js
@@ -1,6 +1,8 @@
 import { CapacitorHttp } from "@capacitor/core";
 import { CANDIDATES_PER_PAGE } from "../common/constants.js";
 import { fetchUserProfile } from "../onboarding/auth.js";
+import { useContext } from "react";
+import { UserContext } from "../common/context.js";
 
 /**
  * @typedef {Object} CandidateSearchResponse
@@ -25,7 +27,7 @@ import { fetchUserProfile } from "../onboarding/auth.js";
  * @param {string} params.startDate - The start date of the candidates
  * @param {string|null} [params.endDate=null] - The end date of the candidates
  * @param {import("../common/constants").SavedStatus} params.savedStatus - The saved status of the candidates
- * @param {string} params.groupIDs - The group IDs to search for
+ * @param {number[]} params.groupIDs - The group IDs to search for
  * @param {string|null} [params.queryID=null] - The query ID
  * @param {number} params.pageNumber - The page number
  * @param {number} [params.numPerPage] - The number of candidates per page
@@ -50,7 +52,7 @@ export async function searchCandidates({
     params: {
       pageNumber: pageNumber.toString(),
       numPerPage: numPerPage.toString(),
-      groupIDs,
+      groupIDs: groupIDs.join(","),
       savedStatus,
       listNameReject: "rejected_candidates",
       startDate,
@@ -115,10 +117,10 @@ export const fetchSourcePhotometry = async ({
  * @param {Object} params
  * @param {string} params.sourceId
  * @param {number[]} params.groupIds
- * @param {import("../onboarding/auth.js").UserInfo} params.userInfo
  * @returns {Promise<any>}
  */
-export const addSourceToGroup = async ({ sourceId, groupIds, userInfo }) => {
+export const addSourceToGroups = async ({ sourceId, groupIds }) => {
+  const userInfo = useContext(UserContext);
   let response = await CapacitorHttp.post({
     url: `${userInfo.instance.url}/api/source_groups`,
     headers: {

--- a/src/scanning/scanningRequests.js
+++ b/src/scanning/scanningRequests.js
@@ -11,6 +11,18 @@ import { fetchUserProfile } from "../onboarding/auth.js";
  */
 
 /**
+ * @typedef {{[key: string]: "number"|"string"|null}} AnnotationKeyInfo
+ */
+
+/**
+ * @typedef {{[key: string]: AnnotationKeyInfo[]}} AnnotationInfoItem
+ */
+
+/**
+ * @typedef {AnnotationInfoItem[]} AnnotationsInfo
+ */
+
+/**
  * Returns the candidates from the API
  * @param {Object} params
  * @param {import("../onboarding/auth.js").UserInfo} params.userInfo - The user info
@@ -149,6 +161,22 @@ export const createNewProfile = async ({ userInfo, profile }) => {
       preferences: {
         scanningProfiles: newScanningProfiles,
       },
+    },
+  });
+  return response.data.data;
+};
+
+/**
+ * @param {Object} params
+ * @param {import("../onboarding/auth.js").UserInfo} params.userInfo
+ * @returns {Promise<AnnotationsInfo>}
+ */
+export const fetchAnnotationInfo = async ({ userInfo }) => {
+  let response = await CapacitorHttp.get({
+    url: `${userInfo.instance.url}/api/internal/annotations_info`,
+    headers: {
+      Authorization: `token ${userInfo.token}`,
+      "Content-Type": "application/json",
     },
   });
   return response.data.data;

--- a/src/scanning/scanningRequests.js
+++ b/src/scanning/scanningRequests.js
@@ -15,11 +15,7 @@ import { fetchUserProfile } from "../onboarding/auth.js";
  */
 
 /**
- * @typedef {{[key: string]: AnnotationKeyInfo[]}} AnnotationInfoItem
- */
-
-/**
- * @typedef {AnnotationInfoItem[]} AnnotationsInfo
+ * @typedef {{[key: string]: AnnotationKeyInfo[]}} AnnotationsInfo
  */
 
 /**

--- a/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
+++ b/src/scanning/scanningSession/CandidateScanner/CandidateScanner.jsx
@@ -1,6 +1,6 @@
 import "./CandidateScanner.scss";
 import { IonModal, useIonAlert, useIonToast } from "@ionic/react";
-import { useCallback, useEffect, useRef, useState, useContext } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import {
   useQueryParams,
   useUserAccessibleGroups,
@@ -65,6 +65,7 @@ export const CandidateScanner = () => {
           .map((id) => userAccessibleGroups.find((g) => g.id === id))
           .filter((g) => g !== undefined)
       : [],
+    pinnedAnnotations: queryParams.pinnedAnnotations.split(","),
     numPerPage,
     queryID: queryParams.queryID,
   };
@@ -382,6 +383,7 @@ export const CandidateScanner = () => {
                 isInView={slidesInView.includes(index)}
                 // @ts-ignore
                 nbCandidates={data.pages[0].totalMatches}
+                pinnedAnnotations={scanningConfig.pinnedAnnotations}
               />
             </div>
           )) ?? (

--- a/src/scanning/scanningSession/MainScanningScreen/MainScanningScreen.jsx
+++ b/src/scanning/scanningSession/MainScanningScreen/MainScanningScreen.jsx
@@ -6,7 +6,7 @@ import React, { Suspense } from "react";
 export const MainScanningScreen = () => {
   return (
     <IonPage className="main-scanning-screen">
-      <IonContent>
+      <IonContent forceOverscroll={false}>
         <Suspense
           fallback={
             <div

--- a/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.jsx
+++ b/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.jsx
@@ -21,17 +21,19 @@ export const PinnedAnnotations = ({
 }) => {
   const handleTextCopied = useCopyAnnotationLineOnClick();
   const [pinnedAnnotations, setPinnedAnnotations] = useState(
-    pinnedAnnotationIds.map((id) => {
-      const lastIndexOfSlash = id.lastIndexOf("/");
-      const annotationOrigin = id.slice(0, lastIndexOfSlash);
-      const dataItem = id.slice(lastIndexOfSlash + 1);
-      return {
-        id: dataItem,
-        value: candidate.annotations.find(
-          (annotation) => annotation.origin === annotationOrigin,
-        )?.data[dataItem],
-      };
-    }),
+    pinnedAnnotationIds
+      .map((id) => {
+        const lastIndexOfSlash = id.lastIndexOf("/");
+        const annotationOrigin = id.slice(0, lastIndexOfSlash);
+        const dataItem = id.slice(lastIndexOfSlash + 1);
+        return {
+          id: dataItem,
+          value: candidate.annotations.find(
+            (annotation) => annotation.origin === annotationOrigin,
+          )?.data[dataItem],
+        };
+      })
+      .filter((annotationItem) => annotationItem.value),
   );
 
   if (pinnedAnnotations.length < 3) {
@@ -43,6 +45,9 @@ export const PinnedAnnotations = ({
         if (
           value &&
           !otherAnnotationIds.find(
+            (annotationItem) => annotationItem.id === annotationId,
+          ) &&
+          !pinnedAnnotations.find(
             (annotationItem) => annotationItem.id === annotationId,
           )
         ) {

--- a/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.jsx
+++ b/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.jsx
@@ -1,7 +1,11 @@
 import "./PinnedAnnotations.scss";
 import { IonButton, IonIcon, IonItem, IonText } from "@ionic/react";
-import { useCopyAnnotationLineOnClick } from "../../scanningLib.js";
+import {
+  getAnnotationId,
+  useCopyAnnotationLineOnClick,
+} from "../../scanningLib.js";
 import { copyOutline } from "ionicons/icons";
+import { useState } from "react";
 
 /**
  * @param {Object} props
@@ -13,22 +17,47 @@ import { copyOutline } from "ionicons/icons";
 export const PinnedAnnotations = ({
   candidate,
   onButtonClick,
-  pinnedAnnotationIds = [
-    "ZTF Science Validation:Public Transients.age",
-    "ZTF Science Validation:Public Transients.acai_b",
-    "ZTF Science Validation:Public Transients.acai_h",
-  ],
+  pinnedAnnotationIds = [],
 }) => {
   const handleTextCopied = useCopyAnnotationLineOnClick();
-  const pinnedAnnotations = pinnedAnnotationIds.map((id) => {
-    const [annotationOrigin, dataItem] = id.split(".");
-    return {
-      id: dataItem,
-      value: candidate.annotations.find(
-        (annotation) => annotation.origin === annotationOrigin,
-      )?.data[dataItem],
-    };
-  });
+  const [pinnedAnnotations, setPinnedAnnotations] = useState(
+    pinnedAnnotationIds.map((id) => {
+      const lastIndexOfSlash = id.lastIndexOf("/");
+      const annotationOrigin = id.slice(0, lastIndexOfSlash);
+      const dataItem = id.slice(lastIndexOfSlash + 1);
+      return {
+        id: dataItem,
+        value: candidate.annotations.find(
+          (annotation) => annotation.origin === annotationOrigin,
+        )?.data[dataItem],
+      };
+    }),
+  );
+
+  if (pinnedAnnotations.length < 3) {
+    /** @type {{id: string, value: string|number}[]} */
+    let otherAnnotationIds = [];
+    outerLoop: for (let annotation of candidate.annotations) {
+      for (let [key, value] of Object.entries(annotation.data)) {
+        const annotationId = getAnnotationId(annotation.origin, key);
+        if (
+          value &&
+          !otherAnnotationIds.find(
+            (annotationItem) => annotationItem.id === annotationId,
+          )
+        ) {
+          otherAnnotationIds.push({
+            id: key,
+            value,
+          });
+          if (otherAnnotationIds.length === 3 - pinnedAnnotations.length) {
+            break outerLoop;
+          }
+        }
+      }
+    }
+    setPinnedAnnotations((prev) => [...prev, ...otherAnnotationIds]);
+  }
 
   return (
     <div className="pinned-annotations">
@@ -49,11 +78,8 @@ export const PinnedAnnotations = ({
             </IonText>
             {"\u00A0"}
             {annotationLine.value ? (
-              <div>
-                {annotationLine.value}
-                {"\u00A0"}
-                {"\u00A0"}
-                {"\u00A0"}
+              <div className="annotation-line-content">
+                <span className="annotation-value">{annotationLine.value}</span>
                 <IonIcon icon={copyOutline} size="small" color="secondary" />
               </div>
             ) : (

--- a/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.jsx
+++ b/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.jsx
@@ -1,6 +1,7 @@
 import "./PinnedAnnotations.scss";
 import { IonButton, IonIcon, IonItem, IonText } from "@ionic/react";
 import {
+  extractAnnotationOriginAndKey,
   getAnnotationId,
   useCopyAnnotationLineOnClick,
 } from "../../scanningLib.js";
@@ -23,14 +24,12 @@ export const PinnedAnnotations = ({
   const [pinnedAnnotations, setPinnedAnnotations] = useState(
     pinnedAnnotationIds
       .map((id) => {
-        const lastIndexOfSlash = id.lastIndexOf("/");
-        const annotationOrigin = id.slice(0, lastIndexOfSlash);
-        const dataItem = id.slice(lastIndexOfSlash + 1);
+        const { key, origin } = extractAnnotationOriginAndKey(id);
         return {
-          id: dataItem,
+          id: key,
           value: candidate.annotations.find(
-            (annotation) => annotation.origin === annotationOrigin,
-          )?.data[dataItem],
+            (annotation) => annotation.origin === origin,
+          )?.data[key],
         };
       })
       .filter((annotationItem) => annotationItem.value),

--- a/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.scss
+++ b/src/scanning/scanningSession/PinnedAnnotations/PinnedAnnotations.scss
@@ -1,12 +1,13 @@
 .pinned-annotations {
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
   padding: 0.5rem;
   border: 0.5px rgba(var(--ion-color-secondary-rgb), 0.3) solid;
   align-self: center;
   border-radius: 0.5rem;
   box-shadow: 0 0 3px rgba(var(--ion-color-medium-rgb), 0.2);
+  height: 100%;
 
   .annotations {
     display: flex;
@@ -30,10 +31,23 @@
       display: flex;
       gap: 0.5rem;
       font-size: 0.9rem;
+
+      .annotation-line-content {
+        display: flex;
+        gap: 0.5rem;
+
+        .annotation-value {
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+          max-lines: 1;
+        }
+      }
     }
   }
 
   .button-container {
     display: flex;
+    width: 5rem;
   }
 }

--- a/src/scanning/scanningSession/ScanningCard/ScanningCard.jsx
+++ b/src/scanning/scanningSession/ScanningCard/ScanningCard.jsx
@@ -14,6 +14,7 @@ import { ScanningCardSkeleton } from "./ScanningCardSkeleton.jsx";
  * @param {number} props.currentIndex
  * @param {number} props.nbCandidates
  * @param {boolean} props.isInView
+ * @param {string[]} props.pinnedAnnotations
  * @returns {JSX.Element}
  */
 const ScanningCardBase = ({
@@ -22,6 +23,7 @@ const ScanningCardBase = ({
   currentIndex,
   nbCandidates,
   isInView,
+  pinnedAnnotations,
 }) => {
   return (
     <div className="scanning-card-container">
@@ -43,6 +45,7 @@ const ScanningCardBase = ({
         <PinnedAnnotations
           candidate={candidate}
           onButtonClick={() => modal.current?.present()}
+          pinnedAnnotationIds={pinnedAnnotations}
         />
         <div className="plot-container">
           <CandidatePhotometryChart

--- a/src/scanning/scanningSession/ScanningCard/ScanningCard.scss
+++ b/src/scanning/scanningSession/ScanningCard/ScanningCard.scss
@@ -7,7 +7,7 @@
 .scanning-card {
   display: grid;
   height: 100%;
-  grid-template-rows: auto auto auto 40%;
+  grid-template-rows: auto auto 13% 40%;
   grid-row-gap: 0.5rem;
   padding: 0.5rem;
   margin: 0 0.4rem;
@@ -55,7 +55,7 @@
     display: flex;
     flex-direction: column;
     flex: 1;
-    max-height: 40vh;
+    max-height: 38vh;
     width: 100%;
     overflow: hidden;
     position: relative;

--- a/src/scanning/scanningSession/ScanningToolbar/ScanningToolbar.scss
+++ b/src/scanning/scanningSession/ScanningToolbar/ScanningToolbar.scss
@@ -1,12 +1,12 @@
 .scanning-toolbar {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
-  background: #ffffff;
+  background: var(--ion-color-light);
   justify-content: space-between;
   align-items: center;
   padding: 0 1.5rem;
   margin: 0.7rem 0.4rem 0;
   border-radius: 1rem;
-  border: 1px solid #c1c7ce;
+  border: 1px solid rgba(var(--ion-color-secondary-rgb), 0.25);
   contain: layout;
 }

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -174,7 +174,7 @@ form {
   }
 
   ion-list.list-ios.list-inset {
-    margin-top: 2rem;
+    margin-top: 1.7rem;
     margin-bottom: 0.5rem;
   }
 

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -174,8 +174,12 @@ form {
   }
 
   ion-list.list-ios.list-inset {
-    margin-top: 0.2rem;
+    margin-top: 2rem;
     margin-bottom: 0.5rem;
+  }
+
+  .form-list-header + ion-list.list-ios.list-inset {
+    margin-top: 0.2rem;
   }
 
   ion-list {


### PR DESCRIPTION
This adds a new line in the scanning options form to let users pick their pinned annotation keys. The selected annotation keys are then used in pinned annotations panel and displayed if they have a value. If some pinned annotations do nat have a value or if the user does not pick any pinned annotations at all, the pinned annotations panel will still try to display something by picking the first non null annotation value it finds.
There is also a small refactor of the CandidateScanner code. And we now use the `state` property from React Router to pass arguments between the form and the scanner instead of the query parameters.

<img width="300" src="https://github.com/user-attachments/assets/cebcb4e5-5cde-48ab-8a7f-43ab86a2b2ad" />
<img width="300" src="https://github.com/user-attachments/assets/d03ee26b-3c40-4f32-b6da-7f8e8e28b9e9" />
<img width="300" src="https://github.com/user-attachments/assets/7ea07613-d89f-4b99-9989-a113e638ff54" />

---

* New PinnedAnnotationsPicker.jsx component
* New ScanningOptionsPinnedAnnotations.jsx component
* New `ANNOTATIONS_INFO` key on the `QUERY_KEYS` constant
* New `fetchAnnotationInfo` functions in scanningRequests.js
* New `useAnnotationsInfo` hook in scanningHooks.js
* Add pinned annotations to the default values of the ScanningOptionsForm.jsx
* Pass `pinnedAnnotations` to the main scanning page along with the other options
* Edit form list styling
* Fix ScanningToolbar colors
* Display annotations even when none is specified
* Display pinned annotations on the scanning card
* New `extractAnnotationOriginAndKey` function in scanningLib.js
* Use `extractAnnotationOriginAndKey` in PinnedAnnotations.jsx
* Add search in PinnedAnnotationsPicker.jsx and make it work
* Use `extractAnnotationOriginAndKey` in ScanningOptionsPinnedAnnotations.jsx to better display the pinned annotations
* Fix annotation info types
* Add selection indicator and fix UI bug in RecentProfiles.jsx
* Adjust some styles
* Change the order of instructions in CandidateScanner.jsx to have all hooks on top
* Use React Router state instead of query parameter for more flexibility
* Move `useContext` inside `useUserAccessibleGroups`
* Remove overscroll in MainScanningScreen.jsx
* Replace `useQueryParams` by `useParams` from React Router