### PR TITLE
Fix XCode Cloud error ITMS-90476 using SO thread

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -38,6 +38,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIRequiresFullScreen</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
XCode Cloud refuses to build the app because of a problem linked to multitasking on iPads. I applied a fix found in an [SO thread](https://stackoverflow.com/questions/32557783/invalid-bundle-error-requires-launch-storyboard).