### PR TITLE
Fix photometry infinite loading

### DIFF
--- a/src/common/common.lib.js
+++ b/src/common/common.lib.js
@@ -64,10 +64,6 @@ import { Preferences } from "@capacitor/preferences";
  */
 
 /**
- * @typedef {"all" | "savedToAllSelected" | "savedToAnySelected" | "savedToAnyAccessible" | "notSavedToAnyAccessible" | "notSavedToAnySelected" | "notSavedToAllSelected"} SavedStatus
- */
-
-/**
  * The instances that are available for login
  * @type {SkyPortalInstance[]}
  */
@@ -102,19 +98,6 @@ export const QUERY_KEYS = {
   INSTRUMENT_FORMS: "instrumentForms",
   INSTRUMENTS: "instruments",
 };
-/**
- * @type {Object.<SavedStatus, string>}
- */
-export const SAVED_STATUS = {
-  ALL: "all",
-  SAVED_TO_ALL_SELECTED: "savedToAllSelected",
-  SAVED_TO_ANY_SELECTED: "savedToAnySelected",
-  SAVED_TO_ANY_ACCESSIBLE: "savedToAnyAccessible",
-  NOT_SAVED_TO_ANY_ACCESSIBLE: "notSavedToAnyAccessible",
-  NOT_SAVED_TO_ANY_SELECTED: "notSavedToAnySelected",
-  NOT_SAVED_TO_ALL_SELECTED: "notSavedToAllSelected",
-};
-export const CANDIDATES_PER_PAGE = 50;
 
 /**
  * Navigate to a new path with params

--- a/src/onboarding/onboarding.lib.js
+++ b/src/onboarding/onboarding.lib.js
@@ -8,23 +8,8 @@ import { CapacitorHttp } from "@capacitor/core";
  */
 
 /**
- * @typedef {Object} ScanningProfile
- * @property {string} name - The name of the scanning profile
- * @property {boolean} default - Whether the profile is the default one
- * @property {number[]} groupIDs - The IDs of the groups that the profile is associated with
- * @property {string} timeRange - The time range of the profile
- * @property {string} [sortingKey] - The key to use to sort the profile
- * @property {import("../common/common.lib.js").SavedStatus} savedStatus - The status of the profile
- * @property {string} [sortingOrder] - The order to use to sort the profile
- * @property {string} [sortingOrigin] - The origin of the sorting
- * @property {string} rejectedStatus - The status of the rejected
- * @property {string} [redshiftMaximum] - The maximum redshift
- * @property {string} [redshiftMinimum] - The minimum redshift
- */
-
-/**
  * @typedef {Object} UserPreferences
- * @property {ScanningProfile[]} scanningProfiles - The scanning profiles of the user
+ * @property {import("../scanning/scanning.lib.js").ScanningProfile[]} scanningProfiles - The scanning profiles of the user
  * @property {number} followupDefault - The default allocation ID for follow-up
  */
 

--- a/src/scanning/scanning.hooks.js
+++ b/src/scanning/scanning.hooks.js
@@ -49,7 +49,7 @@ export const useSearchCandidates = ({ startDate, endDate, savedStatus, groupIDs,
 };
 
 /**
- * @returns {{profiles: import("../onboarding/onboarding.lib.js").ScanningProfile[] | undefined, status: import("@tanstack/react-query").QueryStatus, error: any | undefined}}
+ * @returns {{profiles: import("./scanning.lib.js").ScanningProfile[] | undefined, status: import("@tanstack/react-query").QueryStatus, error: any | undefined}}
  */
 export const useScanningProfiles = () => {
   const { userInfo } = useContext(UserContext);

--- a/src/scanning/scanning.hooks.js
+++ b/src/scanning/scanning.hooks.js
@@ -3,34 +3,19 @@ import { fetchAnnotationInfo, searchCandidates } from "./scanning.requests.js";
 import { fetchUserProfile } from "../onboarding/onboarding.lib.js";
 import { useContext } from "react";
 import { UserContext } from "../common/common.context.js";
-import { useLocation } from "react-router";
 import { CANDIDATES_PER_PAGE, QUERY_KEYS } from "../common/common.lib.js";
 
 /**
+ * @param {Object} props
+ * @param {string} props.startDate - Only includes candidates that passed filters after this date.
+ * @param {string} [props.endDate] - Only includes candidates that passed filters before this date.
+ * @param {import("../common/common.lib.js").SavedStatus} props.savedStatus - The saved status of the candidates
+ * @param {number[]} props.groupIDs - The group IDs linked to the filter passed by the candidates.
+ * @param {string} [props.queryID] - The query ID to filter candidates.
  * @returns {import("@tanstack/react-query").UseInfiniteQueryResult<import("@tanstack/react-query").InfiniteData<import("./scanning.requests.js").CandidateSearchResponse, unknown>, Error>}
  */
-export const useSearchCandidates = () => {
+export const useSearchCandidates = ({ startDate, endDate, savedStatus, groupIDs, queryID }) => {
   const { userInfo } = useContext(UserContext);
-  /** @type {any} */
-  const { state } = useLocation();
-  /** @type {string} */
-  let startDate = "";
-  /** @type {string} */
-  let endDate = "";
-  /** @type {import("../common/common.lib.js").SavedStatus} */
-  let savedStatus = "all";
-  /** @type {number[]} */
-  let groupIDs = [];
-  /** @type {string} */
-  let queryID = "";
-
-  if (state) {
-    startDate = state.startDate;
-    endDate = state.endDate;
-    savedStatus = state.savedStatus;
-    groupIDs = state.saveGroupIds;
-    queryID = state.queryID;
-  }
 
   return useInfiniteQuery({
     queryKey: [
@@ -41,9 +26,6 @@ export const useSearchCandidates = () => {
       groupIDs,
     ],
     queryFn: async (ctx) => {
-      if (!startDate || !endDate || !savedStatus || !groupIDs) {
-        throw new Error("Missing parameters");
-      }
       return await searchCandidates({
         userInfo,
         startDate,
@@ -61,7 +43,7 @@ export const useSearchCandidates = () => {
       }
       return +lastPage.pageNumber + 1;
     },
-    enabled: !!state,
+    enabled: !!(startDate && savedStatus && groupIDs.length),
   });
 };
 

--- a/src/scanning/scanning.hooks.js
+++ b/src/scanning/scanning.hooks.js
@@ -1,15 +1,16 @@
+import { useContext } from "react";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { fetchAnnotationInfo, searchCandidates } from "./scanning.requests.js";
+import { CANDIDATES_PER_PAGE } from "./scanning.lib.js";
 import { fetchUserProfile } from "../onboarding/onboarding.lib.js";
-import { useContext } from "react";
 import { UserContext } from "../common/common.context.js";
-import { CANDIDATES_PER_PAGE, QUERY_KEYS } from "../common/common.lib.js";
+import { QUERY_KEYS } from "../common/common.lib.js";
 
 /**
  * @param {Object} props
  * @param {string} props.startDate - Only includes candidates that passed filters after this date.
  * @param {string} [props.endDate] - Only includes candidates that passed filters before this date.
- * @param {import("../common/common.lib.js").SavedStatus} props.savedStatus - The saved status of the candidates
+ * @param {import("./scanning.lib.js").SavedStatus} props.savedStatus - The saved status of the candidates
  * @param {number[]} props.groupIDs - The group IDs linked to the filter passed by the candidates.
  * @param {string} [props.queryID] - The query ID to filter candidates.
  * @returns {import("@tanstack/react-query").UseInfiniteQueryResult<import("@tanstack/react-query").InfiniteData<import("./scanning.requests.js").CandidateSearchResponse, unknown>, Error>}

--- a/src/scanning/scanning.lib.js
+++ b/src/scanning/scanning.lib.js
@@ -32,7 +32,7 @@
  * @typedef {Object} ScanningConfig
  * @property {string} startDate
  * @property {string} endDate
- * @property {import("../common/common.lib.js").SavedStatus} savedStatus
+ * @property {SavedStatus} savedStatus
  * @property {number[]} saveGroupIds
  * @property {Group[]} saveGroups
  * @property {number[]} junkGroupIDs
@@ -52,10 +52,26 @@
  * @property {Candidate[]} notAssigned
  */
 
+/**
+ * @typedef {"all" | "savedToAllSelected" | "savedToAnySelected" | "savedToAnyAccessible" | "notSavedToAnyAccessible" | "notSavedToAnySelected" | "notSavedToAllSelected"} SavedStatus
+ */
+
 import config from "../config.js";
 import moment from "moment-timezone";
 
-import { SAVED_STATUS } from "../common/common.lib.js";
+/**
+ * @type {Object.<SavedStatus, string>}
+ */
+export const SAVED_STATUS = {
+  ALL: "all",
+  SAVED_TO_ALL_SELECTED: "savedToAllSelected",
+  SAVED_TO_ANY_SELECTED: "savedToAnySelected",
+  SAVED_TO_ANY_ACCESSIBLE: "savedToAnyAccessible",
+  NOT_SAVED_TO_ANY_ACCESSIBLE: "notSavedToAnyAccessible",
+  NOT_SAVED_TO_ANY_SELECTED: "notSavedToAnySelected",
+  NOT_SAVED_TO_ALL_SELECTED: "notSavedToAllSelected",
+};
+export const CANDIDATES_PER_PAGE = 10;
 
 /**
  * @param {Object} params
@@ -359,7 +375,7 @@ export const getFiltering = (scanningProfile) => {
  * @param {boolean} data.filterCandidates
  * @param {string} data.filteringType
  * @param {string} data.filteringAnyOrAll
- * @returns {import("../common/common.lib.js").SavedStatus}
+ * @returns {SavedStatus}
  */
 export const computeSavedStatus = ({
   filterCandidates,

--- a/src/scanning/scanning.lib.js
+++ b/src/scanning/scanning.lib.js
@@ -9,6 +9,21 @@
 /** @typedef {import("../sources/sources.lib.js").Annotation} Annotation */
 
 /**
+ * @typedef {Object} ScanningProfile
+ * @property {string} name - The name of the scanning profile
+ * @property {boolean} default - Whether the profile is the default one
+ * @property {number[]} groupIDs - The IDs of the groups that the profile is associated with
+ * @property {string} timeRange - The time range of the profile
+ * @property {string} [sortingKey] - The key to use to sort the profile
+ * @property {SavedStatus} savedStatus - The status of the profile
+ * @property {string} [sortingOrder] - The order to use to sort the profile
+ * @property {string} [sortingOrigin] - The origin of the sorting
+ * @property {string} rejectedStatus - The status of the rejected
+ * @property {string} [redshiftMaximum] - The maximum redshift
+ * @property {string} [redshiftMinimum] - The minimum redshift
+ */
+
+/**
  * @typedef {Object} Candidate
  * @property {number} ra - Right ascension
  * @property {number} dec - Declination
@@ -321,7 +336,7 @@ export const parseIntList = (intListString) => {
 
 /**
  *
- * @param {import("../onboarding/onboarding.lib.js").ScanningProfile} scanningProfile
+ * @param {import("./scanning.lib.js").ScanningProfile} scanningProfile
  * @returns {string}
  */
 export const getStartDate = (scanningProfile) => {
@@ -331,7 +346,7 @@ export const getStartDate = (scanningProfile) => {
 };
 
 /**
- * @param {import("../onboarding/onboarding.lib.js").ScanningProfile} scanningProfile
+ * @param {import("./scanning.lib.js").ScanningProfile} scanningProfile
  */
 export const getFiltering = (scanningProfile) => {
   switch (scanningProfile.savedStatus) {

--- a/src/scanning/scanning.requests.js
+++ b/src/scanning/scanning.requests.js
@@ -57,7 +57,6 @@ export async function searchCandidates({
       queryID: queryID || "",
       includeFollowupRequests: "true",
       includeComments: "true",
-      includeSpectra: "true",
     },
   });
   return {

--- a/src/scanning/scanning.requests.js
+++ b/src/scanning/scanning.requests.js
@@ -1,6 +1,6 @@
 import { CapacitorHttp } from "@capacitor/core";
 import { fetchUserProfile } from "../onboarding/onboarding.lib.js";
-import { CANDIDATES_PER_PAGE } from "../common/common.lib.js";
+import { CANDIDATES_PER_PAGE } from "./scanning.lib.js";
 
 /**
  * @typedef {Object} CandidateSearchResponse
@@ -24,7 +24,7 @@ import { CANDIDATES_PER_PAGE } from "../common/common.lib.js";
  * @param {import("../onboarding/onboarding.lib.js").UserInfo} params.userInfo - The user info
  * @param {string} params.startDate - The start date of the candidates
  * @param {string|null} [params.endDate=null] - The end date of the candidates
- * @param {import("../common/common.lib.js").SavedStatus} params.savedStatus - The saved status of the candidates
+ * @param {import("./scanning.lib.js").SavedStatus} params.savedStatus - The saved status of the candidates
  * @param {number[]} params.groupIDs - The group IDs to search for
  * @param {string|null} [params.queryID=null] - The query ID
  * @param {number} params.pageNumber - The page number
@@ -70,7 +70,7 @@ export async function searchCandidates({
 /**
  * @param {Object} params
  * @param {import("../onboarding/onboarding.lib.js").UserInfo} params.userInfo
- * @param {import("../onboarding/onboarding.lib.js").ScanningProfile} params.profile
+ * @param {import("./scanning.lib.js").ScanningProfile} params.profile
  * @returns {Promise<*>}
  */
 export const createNewProfile = async ({ userInfo, profile }) => {

--- a/src/scanning/scanningOptions/components/ProfileListItem/ProfileListItem.jsx
+++ b/src/scanning/scanningOptions/components/ProfileListItem/ProfileListItem.jsx
@@ -13,11 +13,11 @@ import { useRef } from "react";
 
 /**
  * @param {Object} props
- * @param {import("../../../../onboarding/onboarding.lib.js").ScanningProfile} props.profile
+ * @param {import("../../../../scanning/scanning.lib.js").ScanningProfile} props.profile
  * @param {import("../../../scanning.lib.js").Group[]} props.userAccessibleGroups
  * @param {boolean} [props.itemSliding=false]
  * @param {() => void} [props.onClick]
- * @param {(profile: import("../../../../onboarding/onboarding.lib.js").ScanningProfile) => void} [props.onDelete]
+ * @param {(profile: import("../../../../scanning/scanning.lib.js").ScanningProfile) => void} [props.onDelete]
  * @returns {JSX.Element}
  */
 export const ProfileListItem = ({

--- a/src/scanning/scanningOptions/components/RecentProfiles/RecentProfiles.jsx
+++ b/src/scanning/scanningOptions/components/RecentProfiles/RecentProfiles.jsx
@@ -17,7 +17,7 @@ export const RecentProfiles = () => {
 
   const handleScanWithProfile = useCallback(
     /**
-     * @param {import("../../../../onboarding/onboarding.lib.js").ScanningProfile} profile
+     * @param {import("../../../../scanning/scanning.lib.js").ScanningProfile} profile
      */
     (profile) => {
       navigateWithParams(history, "/scanning", {

--- a/src/scanning/scanningOptions/components/ScanningProfileCreator/ScanningProfileCreator.jsx
+++ b/src/scanning/scanningOptions/components/ScanningProfileCreator/ScanningProfileCreator.jsx
@@ -41,7 +41,7 @@ export const ScanningProfileCreator = () => {
       });
       return;
     }
-    /** @type {import("../../../../onboarding/onboarding.lib.js").ScanningProfile} */
+    /** @type {import("../../../scanning.lib.js").ScanningProfile} */
     const profile = {
       name: data.profileName,
       default: true,

--- a/src/scanning/scanningOptions/screens/ScanningProfilesScreen/ScanningProfilesScreen.jsx
+++ b/src/scanning/scanningOptions/screens/ScanningProfilesScreen/ScanningProfilesScreen.jsx
@@ -26,7 +26,7 @@ export const ScanningProfilesScreen = () => {
 
   const handleOnProfileClick = useCallback(
     /**
-     * @param {import("../../../../onboarding/onboarding.lib.js").ScanningProfile} profile
+     * @param {import("../../../scanning.lib.js").ScanningProfile} profile
      */
     (profile) => {
       navigateWithParams(history, "/scanning", {

--- a/src/scanning/scanningSession/components/CandidateList/CandidateList.jsx
+++ b/src/scanning/scanningSession/components/CandidateList/CandidateList.jsx
@@ -20,41 +20,30 @@ import { CANDIDATES_PER_PAGE, QUERY_KEYS } from "../../../../common/common.lib.j
 import { RequestFollowupModal } from "../../../../sources/components/FollowupRequests/RequestFollowupModal.jsx";
 
 export const CandidateList = () => {
+  /** @type {{state: import("../../../scanning.lib.js").ScanningConfig|undefined}} */
+  let { state } = useLocation();
+  const {
+    startDate,
+    endDate,
+    savedStatus,
+    saveGroupIds: groupIDs,
+    queryID,
+  } = state ?? {};
+  if (!startDate || !savedStatus || !groupIDs?.length) {
+    return null;
+  }
   const { userInfo } = useContext(UserContext);
   const queryClient = useQueryClient();
   const { userAccessibleGroups } = useUserAccessibleGroups();
   const updateSourceGroups = useUpdateSourceGroups();
-
-  /** @type {{state: any}} */
-  const { state } = useLocation();
-
-  /**
-   * @param {number[]|undefined} ids
-   * @param {import("../../../scanning.lib.js").Group[] | undefined} availableGroups
-   */
-  const resolveGroups = (ids, availableGroups) => {
-    return (ids ?? []).map((id) => availableGroups?.find((g) => g.id === id))
-      .filter((g) => g !== undefined);
-  }
-
-  /** @type {import("../../../scanning.lib.js").ScanningConfig|undefined} */
-  let scanningConfig = undefined;
-  if (state) {
-    scanningConfig = {
-      ...state,
-      saveGroups: resolveGroups(state.saveGroupIds, userAccessibleGroups),
-      junkGroups: resolveGroups(state.junkGroupIDs, userAccessibleGroups),
-      pinnedAnnotations: state.pinnedAnnotations,
-      queryID: state.queryID,
-      totalMatches: state.totalMatches,
-    };
-  }
-
   const [currentIndex, setCurrentIndex] = useState(0);
   const [emblaRef, emblaApi] = useEmblaCarousel();
   /** @type {[number[], React.Dispatch<number[]>]} */
   // @ts-ignore
   const [slidesInView, setSlidesInView] = useState([]);
+  const [presentAlert] = useIonAlert();
+  const confirmAlert = useConfirmAlert();
+  const errorToast = useErrorToast();
 
   /** @type {React.MutableRefObject<any>} */
   const requestFollowupModal = useRef(null);
@@ -68,15 +57,26 @@ export const CandidateList = () => {
     notAssigned: [],
     totalMatches: 0,
   });
-  const { data, fetchNextPage, isFetchingNextPage } = useSearchCandidates();
+  const { data, fetchNextPage, isFetchingNextPage } = useSearchCandidates({
+    startDate,
+    endDate,
+    savedStatus,
+    groupIDs,
+    queryID,
+  });
   const totalMatches = data?.pages[0].totalMatches;
   /** @type {import("../../../scanning.lib.js").Candidate[]|undefined} */
   const candidates = data?.pages.map((page) => page.candidates).flat(1);
   const currentCandidate = candidates?.at(currentIndex);
 
-  const [presentAlert] = useIonAlert();
-  const confirmAlert = useConfirmAlert();
-  const errorToast = useErrorToast();
+  /**
+   * @param {number[]|undefined} ids
+   * @param {import("../../../scanning.lib.js").Group[] | undefined} availableGroups
+   */
+  const resolveGroups = (ids, availableGroups) => {
+    return (ids ?? []).map((id) => availableGroups?.find((g) => g.id === id))
+      .filter((g) => g !== undefined);
+  }
 
   useEffect(() => {
     if (emblaApi) {
@@ -91,7 +91,7 @@ export const CandidateList = () => {
 
   const slidesInViewCallback = useCallback(
     async (/** @type {import("embla-carousel").EmblaCarouselType} */ e) => {
-      if (!scanningConfig) return;
+      if (!state) return;
       if (
         !isFetchingNextPage &&
         e.selectedScrollSnap() >= e.slideNodes().length - 4 &&
@@ -125,7 +125,7 @@ export const CandidateList = () => {
      */
     (action) =>
       new Promise((resolve, reject) => {
-        if (!scanningConfig || !currentCandidate) {
+        if (!state || !currentCandidate) {
           reject();
           return;
         }
@@ -134,10 +134,9 @@ export const CandidateList = () => {
             action === "save" ? "Select a program" : "Select a junk group",
           buttons: [action === "save" ? "Save" : "Discard"],
           /** @type {import("@ionic/react").AlertInput[]} */
-          inputs: (action === "save"
-            ? scanningConfig.saveGroups
-            : scanningConfig.junkGroups
-          ).map((group) => ({
+          inputs: resolveGroups(
+            action === "save" ? state.saveGroupIds : state.junkGroupIDs,
+              userAccessibleGroups).map((group) => ({
             disabled: currentCandidate.saved_groups.some((g) => g.id === group.id),
             type: "checkbox",
             label: group.name,
@@ -150,14 +149,14 @@ export const CandidateList = () => {
           },
         })
       }),
-    [state, currentCandidate, presentAlert, scanningConfig, userAccessibleGroups],
+    [state, currentCandidate, presentAlert, state, userAccessibleGroups],
   );
 
   const handleSave = useCallback(async () => {
-    if (!currentCandidate || !scanningConfig) {
+    if (!currentCandidate || !state) {
       return;
     }
-    if (scanningConfig.saveGroupIds.length > 1) {
+    if (state.saveGroupIds.length > 1) {
       const groupIdsToAdd = await promptUserForGroupSelection("save");
       if (groupIdsToAdd.length > 0) {
         updateSourceGroups.mutate({
@@ -173,7 +172,7 @@ export const CandidateList = () => {
 
       updateSourceGroups.mutate({
         sourceId: currentCandidate.id,
-        groupIdsToAdd: scanningConfig.saveGroupIds.map(String),
+        groupIdsToAdd: state.saveGroupIds.map(String),
       });
     }
     scanningRecap.current = {
@@ -183,19 +182,19 @@ export const CandidateList = () => {
   }, [currentCandidate, state]);
 
   const handleDiscard = useCallback(async () => {
-    if (!currentCandidate || !scanningConfig) {
+    if (!currentCandidate || !state) {
       return;
     }
     let groupIdsToAdd;
-    if (scanningConfig.discardBehavior === "ask") {
+    if (state.discardBehavior === "ask") {
       groupIdsToAdd = await promptUserForGroupSelection("discard");
       if (groupIdsToAdd.length === 0) {
         errorToast("No group selected, please select at least one group");
         return;
       }
     } else {
-      groupIdsToAdd = (scanningConfig.discardBehavior === "specific" && scanningConfig.discardGroup ?
-        [scanningConfig.discardGroup] : scanningConfig.junkGroupIDs.map(String))
+      groupIdsToAdd = (state.discardBehavior === "specific" && state.discardGroup ?
+        [state.discardGroup] : state.junkGroupIDs.map(String))
         .filter((id) => !currentCandidate.saved_groups.some((g) => g.id === id),
       ).map(String);
       if (groupIdsToAdd.length === 0) {
@@ -218,9 +217,9 @@ export const CandidateList = () => {
     if (confirmed) history.back();
   }, [presentAlert]);
 
-  const isDiscardingEnabled = (scanningConfig?.junkGroupIDs?.length ?? 0) > 0;
+  const isDiscardingEnabled = (state?.junkGroupIDs?.length ?? 0) > 0;
 
-  scanningRecap.current.queryId = scanningConfig?.queryID ?? "";
+  scanningRecap.current.queryId = state?.queryID ?? "";
   scanningRecap.current.totalMatches = totalMatches ?? 0;
 
   if (candidates && candidates.length === totalMatches && !isLastBatch) {
@@ -303,9 +302,9 @@ export const CandidateList = () => {
     <div className="candidate-list">
       <div className="embla" ref={emblaRef}>
         <div className="embla__container">
-          {scanningConfig && candidates ? (
+          {state && candidates ? (
             <>
-              {scanningConfig && candidates.map((candidate, index) => (
+              {candidates.map((candidate, index) => (
                 <div key={candidate.id} className="embla__slide">
                   <ScanningCard
                     candidate={candidate}
@@ -314,7 +313,7 @@ export const CandidateList = () => {
                     // @ts-ignore
                     nbCandidates={data.pages[0].totalMatches}
                     // @ts-ignore
-                    pinnedAnnotations={scanningConfig.pinnedAnnotations}
+                    pinnedAnnotations={state.pinnedAnnotations}
                   />
                 </div>
               ))}

--- a/src/scanning/scanningSession/components/CandidateList/CandidateList.jsx
+++ b/src/scanning/scanningSession/components/CandidateList/CandidateList.jsx
@@ -57,7 +57,7 @@ export const CandidateList = () => {
     notAssigned: [],
     totalMatches: 0,
   });
-  const { data, fetchNextPage, isFetchingNextPage } = useSearchCandidates({
+  const { data, isError, isFetched, fetchNextPage, isFetchingNextPage } = useSearchCandidates({
     startDate,
     endDate,
     savedStatus,
@@ -65,6 +65,25 @@ export const CandidateList = () => {
     queryID,
   });
   const totalMatches = data?.pages[0].totalMatches;
+  useEffect(() => {
+    if (isFetched && (isError || totalMatches === 0)) {
+      presentAlert({
+        header: isError ? "Error" : "No candidates found",
+        message:
+          isError ?
+            "An error occurred while searching for candidates. Please try again." :
+            "No candidates were found with the selected options. Please try again.",
+        buttons: [
+          {
+            text: "OK",
+            handler: () => {
+              history.back();
+            },
+          },
+        ],
+      })
+    }
+  }, [isFetched, isError, totalMatches, presentAlert]);
   /** @type {import("../../../scanning.lib.js").Candidate[]|undefined} */
   const candidates = data?.pages.map((page) => page.candidates).flat(1);
   const currentCandidate = candidates?.at(currentIndex);
@@ -222,7 +241,7 @@ export const CandidateList = () => {
   scanningRecap.current.queryId = state?.queryID ?? "";
   scanningRecap.current.totalMatches = totalMatches ?? 0;
 
-  if (candidates && candidates.length === totalMatches && !isLastBatch) {
+  if (candidates?.length === totalMatches && !isLastBatch) {
     setIsLastBatch(true);
   }
 
@@ -317,7 +336,7 @@ export const CandidateList = () => {
                   />
                 </div>
               ))}
-              {isLastBatch && (
+              {totalMatches && isLastBatch && (
                 <div className="embla__slide">
                   <ScanningEnd recap={scanningRecap} />
                 </div>

--- a/src/scanning/scanningSession/components/CandidateList/CandidateList.jsx
+++ b/src/scanning/scanningSession/components/CandidateList/CandidateList.jsx
@@ -16,7 +16,8 @@ import { SCANNING_TOOLBAR_ACTION } from "../../../scanning.lib.js";
 import { ScanningEnd } from "../ScanningEnd/ScanningEnd.jsx";
 import { ScanningToolbar } from "../ScanningToolbar/ScanningToolbar.jsx";
 import { UserContext } from "../../../../common/common.context.js";
-import { CANDIDATES_PER_PAGE, QUERY_KEYS } from "../../../../common/common.lib.js";
+import { CANDIDATES_PER_PAGE } from "../../../scanning.lib.js";
+import { QUERY_KEYS } from "../../../../common/common.lib.js";
 import { RequestFollowupModal } from "../../../../sources/components/FollowupRequests/RequestFollowupModal.jsx";
 
 export const CandidateList = () => {

--- a/src/scanning/scanningSession/components/CandidateList/CandidateList.jsx
+++ b/src/scanning/scanningSession/components/CandidateList/CandidateList.jsx
@@ -22,7 +22,7 @@ import { RequestFollowupModal } from "../../../../sources/components/FollowupReq
 
 export const CandidateList = () => {
   /** @type {{state: import("../../../scanning.lib.js").ScanningConfig|undefined}} */
-  let { state } = useLocation();
+  const { state } = useLocation();
   const {
     startDate,
     endDate,

--- a/src/scanning/scanningSession/components/CandidateList/CandidateList.jsx
+++ b/src/scanning/scanningSession/components/CandidateList/CandidateList.jsx
@@ -169,7 +169,7 @@ export const CandidateList = () => {
           },
         })
       }),
-    [state, currentCandidate, presentAlert, state, userAccessibleGroups],
+    [state, currentCandidate, presentAlert, userAccessibleGroups],
   );
 
   const handleSave = useCallback(async () => {

--- a/src/scanning/scanningSession/components/ScanningCard/ScanningCard.jsx
+++ b/src/scanning/scanningSession/components/ScanningCard/ScanningCard.jsx
@@ -74,7 +74,7 @@ const ScanningCardBase = ({
         </div>
         <SourceInfo source={candidate} />
         <Comments comments={candidate.comments} />
-        <SpectraList sourceId={candidate.id} />
+        <SpectraList sourceId={candidate.id} isInView={isInView} />
         <FollowupRequests source={candidate} requestType={"triggered"} />
         <FollowupRequests source={candidate} requestType={"forced_photometry"}/>
       </div>

--- a/src/sources/components/AnnotationItem/AnnotationItem.jsx
+++ b/src/sources/components/AnnotationItem/AnnotationItem.jsx
@@ -27,13 +27,14 @@ export const AnnotationItem = ({ annotation }) => {
               detail={false}
               button
             >
-              <IonText color="secondary">{key}:</IonText>
-              {"\u00A0"}
-              <IonText>{sanitizeAnnotationData(value,false)}</IonText>
-              {"\u00A0"}
-              {"\u00A0"}
-              {"\u00A0"}
-              <IonIcon icon={copyOutline} size="small" color="secondary" />
+              <IonText color="secondary" style={{ marginRight: "0.5rem" }}>
+                {key}:
+              </IonText>
+              <IonText style={{ wordBreak: "break-word", marginRight: "0.5rem"}}
+              >
+                {sanitizeAnnotationData(value,false)}
+              </IonText>
+              <IonIcon icon={copyOutline} size="small" color="secondary" style={{ minWidth: "19.125px" }} />
             </IonItem>
           ))}
       </IonList>

--- a/src/sources/components/Annotations/Annotations.scss
+++ b/src/sources/components/Annotations/Annotations.scss
@@ -1,6 +1,5 @@
 .annotations {
   display: flex;
   flex-direction: column;
-  height: 10vh;
   width: 100%;
 }

--- a/src/sources/components/Comments/Comments.scss
+++ b/src/sources/components/Comments/Comments.scss
@@ -11,6 +11,7 @@
     }
     .text {
       text-align: left;
+      word-break: break-word;
     }
     .highlight {
       color: var(--ion-color-primary);

--- a/src/sources/components/PhotometryChart/PhotometryChart.jsx
+++ b/src/sources/components/PhotometryChart/PhotometryChart.jsx
@@ -1,12 +1,10 @@
 import "./PhotometryChart.scss";
-import { memo, useContext, useEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import embed from "vega-embed";
 import { getVegaPlotSpec } from "../../../scanning/scanning.lib.js";
 import { useBandpassesColors } from "../../../common/common.hooks.js";
 import { IonSkeletonText } from "@ionic/react";
-import { fetchSourcePhotometry } from "../../sources.requests.js";
-import { useMutation } from "@tanstack/react-query";
-import { UserContext } from "../../../common/common.context.js";
+import { useSourcePhotometry } from "../../sources.hooks.js";
 
 /**
  * @param {Object} props
@@ -14,10 +12,9 @@ import { UserContext } from "../../../common/common.context.js";
  * @param {boolean} [props.isInView]
  * @returns {JSX.Element}
  */
-const PhotometryChartBase = ({ sourceId, isInView= true }) => {
-  const { userInfo } = useContext(UserContext);
+const PhotometryChartBase = ({ sourceId, isInView = true }) => {
+  const { photometry, status } = useSourcePhotometry(sourceId, isInView);
   const [hasLoaded, setHasLoaded] = useState(false);
-  const [loaderIsHidden, setLoaderIsHidden] = useState(false);
   /** @type {React.MutableRefObject<HTMLDivElement|null>} */
   const container = useRef(null);
   const unmountVega = useRef(() => {});
@@ -25,67 +22,44 @@ const PhotometryChartBase = ({ sourceId, isInView= true }) => {
   /** @type {React.MutableRefObject<NodeJS.Timeout|undefined>} */
   const revealTimeout = useRef(undefined);
 
-  const mountMutation = useMutation({
-    mutationFn: async () => {
-      const photometry = await fetchSourcePhotometry({
-        sourceId: sourceId,
-        userInfo,
-      });
-      if (!container.current || !bandpassesColors || !photometry) {
-        throw new Error("Missing parameters");
-      }
-      const response = await embed(
+  const renderVega = useCallback(async () => {
+    if (!photometry || !container.current || !bandpassesColors) return;
+
+    const result = await embed(
+      // @ts-ignore
+      container.current,
+      getVegaPlotSpec({
+        photometry,
+        titleFontSize: 13,
+        labelFontSize: 11,
         // @ts-ignore
-        container.current,
-        getVegaPlotSpec({
-          photometry,
-          titleFontSize: 13,
-          labelFontSize: 11,
-          // @ts-ignore
-          bandpassesColors,
-        }),
-        {
-          actions: false,
-        },
-      );
-      unmountVega.current = response.finalize;
-    },
-    onSuccess: () => {
-      revealTimeout.current = setTimeout(() => {
-        setHasLoaded(true);
-      }, 300);
-    },
-  });
+        bandpassesColors,
+      }),
+      { actions: false }
+    );
+
+    unmountVega.current = result.finalize;
+    revealTimeout.current = setTimeout(() => setHasLoaded(true), 300);
+  }, [photometry, bandpassesColors]);
 
   useEffect(() => {
     if (!isInView) {
+      unmountVega.current();
+      setHasLoaded(false);
       if (container.current) {
         const canvas = container.current.getElementsByTagName("canvas")[0];
         if (canvas) {
           canvas.height = 0;
           canvas.width = 0;
-          unmountVega.current();
-          setHasLoaded(false);
         }
       }
-    } else {
-      mountMutation.mutate();
+    } else if (status === "success" && !hasLoaded) {
+      renderVega();
     }
     return () => {
       clearTimeout(revealTimeout.current);
     };
-  }, [isInView, bandpassesColors]);
-
-  useEffect(() => {
-    /**@type {any} */
-    let hideTimeout;
-    if (hasLoaded && !loaderIsHidden) {
-      hideTimeout = setTimeout(() => setLoaderIsHidden(true), 300);
-    }
-    return () => {
-      clearTimeout(hideTimeout);
-    };
-  }, [hasLoaded, loaderIsHidden]);
+  }, [isInView, status, renderVega]);
 
   return (
     <div className="photometry-chart">
@@ -97,7 +71,7 @@ const PhotometryChartBase = ({ sourceId, isInView= true }) => {
       <div
         className={`canvas-loading ${hasLoaded ? "loaded" : "loading"}`}
         style={{
-          visibility: loaderIsHidden ? "hidden" : "visible",
+          visibility: hasLoaded ? "hidden" : "visible",
         }}
       >
         <IonSkeletonText animated />

--- a/src/sources/components/PhotometryChart/PhotometryChart.jsx
+++ b/src/sources/components/PhotometryChart/PhotometryChart.jsx
@@ -44,7 +44,7 @@ const PhotometryChartBase = ({ sourceId, isInView = true }) => {
 
   useEffect(() => {
     if (!isInView) {
-      unmountVega.current();
+      if (unmountVega.current) unmountVega.current();
       setHasLoaded(false);
       if (container.current) {
         const canvas = container.current.getElementsByTagName("canvas")[0];

--- a/src/sources/components/PinnedAnnotations/AnnotationsViewerModal.jsx
+++ b/src/sources/components/PinnedAnnotations/AnnotationsViewerModal.jsx
@@ -11,14 +11,13 @@ export const AnnotationsViewerModal = ({ source, modal }) => {
   return (
     <IonModal
       ref={modal}
-      isOpen={false}
       initialBreakpoint={0.75}
-      breakpoints={[0, 0.25, 0.5, 0.75]}
+      breakpoints={[0.75, 1]}
     >
       <IonHeader>
         <IonSearchbar />
       </IonHeader>
-      <IonContent>
+      <IonContent style={{ "--padding-bottom": "2rem"}}>
         <Annotations source={source} />
       </IonContent>
     </IonModal>

--- a/src/sources/components/Spectra/SpectraList.jsx
+++ b/src/sources/components/Spectra/SpectraList.jsx
@@ -16,10 +16,11 @@ import { useSourceSpectra } from "../../sources.hooks.js";
 /**
  * @param {Object} props
  * @param {string} props.sourceId - The ID of the source to fetch spectra for
+ * @param {boolean} [props.isInView] - Whether the component is currently in view
  * @returns {JSX.Element | null}
  */
-export const SpectraList = ({sourceId}) => {
-  const { spectraList } = useSourceSpectra(sourceId);
+export const SpectraList = ({sourceId, isInView = true}) => {
+  const { spectraList } = useSourceSpectra(sourceId, isInView);
   /** @type {[Spectra | null, React.Dispatch<React.SetStateAction<Spectra | null>>]} */
   // @ts-ignore
   const [openSpectra, setOpenSpectra] = useState(null);

--- a/src/sources/sources.hooks.js
+++ b/src/sources/sources.hooks.js
@@ -6,10 +6,11 @@ import {
   addToFavorites,
   fetchFavorites,
   fetchSource,
+  fetchSourcePhotometry,
   fetchSourceSpectra,
   removeFromFavorites,
   submitFollowupRequest,
-  updateSourceGroups
+  updateSourceGroups,
 } from "./sources.requests.js";
 import { fetchSources } from "./sources.requests.js";
 import { checkmarkCircleOutline } from "ionicons/icons";
@@ -82,9 +83,10 @@ export const useFetchSource = ({ sourceId, params = {} }) => {
 
 /**
  * @param {string} sourceId
+ * @param {boolean} [enableFetch=true] - If false, the query will not be executed
  * @returns {{spectraList: import("./sources.lib.js").Spectra[] | undefined, status: import("@tanstack/react-query").QueryStatus, error: any | undefined }}
  */
-export const useSourceSpectra = (sourceId) => {
+export const useSourceSpectra = (sourceId, enableFetch = true) => {
   const { userInfo } = useContext(UserContext);
   const {
     data: spectraList,
@@ -98,10 +100,38 @@ export const useSourceSpectra = (sourceId) => {
       }
       return await fetchSourceSpectra({ userInfo, sourceId });
     },
-    enabled: !!sourceId,
+    enabled: enableFetch && !!sourceId,
   });
   return {
     spectraList,
+    status,
+    error,
+  };
+}
+
+/**
+ * @param {string} sourceId
+ * @param {boolean} [enableFetch=true] - If false, the query will not be executed
+ * @returns {{photometry: import("./sources.lib.js").Photometry[] | undefined, status: import("@tanstack/react-query").QueryStatus, error: any | undefined }}
+ */
+export const useSourcePhotometry = (sourceId, enableFetch = true) => {
+  const { userInfo } = useContext(UserContext);
+  const {
+    data: photometry,
+    status,
+    error,
+  } = useQuery({
+    queryKey: [QUERY_KEYS.SOURCE_PHOTOMETRY, sourceId],
+    queryFn: async () => {
+      if (!sourceId) {
+        throw new Error("Missing sourceId");
+      }
+      return await fetchSourcePhotometry({ userInfo, sourceId });
+    },
+    enabled: enableFetch && !!sourceId,
+  });
+  return {
+    photometry,
     status,
     error,
   };


### PR DESCRIPTION
- Fix bad double fetching of the candidates and delete useless codes.
- Remove useless includeSpectra parameter from scanning requests to speed up data loading
- Fetch photometry and spectroscopy of each candidate only when the candidate card is display to avoid overwhelming fritz and get "Too many requests" error.
- It turns out there was indeed a paging mechanism, but since the number of candidates per page was set to 50, it was still overloading the server and making the candidate search far too slow. I then reduced the number of candidates per page to 10, which significantly speeds up the candidate loading process.
- Fix long comment overflow.
- Fix annotations not scrolling properly.