### PR TITLE
Fix ion safe area on android

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation project(':capacitor-keyboard')
     implementation project(':capacitor-preferences')
     implementation project(':capacitor-status-bar')
+    implementation project(':capacitor-plugin-safe-area')
 
 }
 

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -25,3 +25,6 @@ project(':capacitor-preferences').projectDir = new File('../node_modules/@capaci
 
 include ':capacitor-status-bar'
 project(':capacitor-status-bar').projectDir = new File('../node_modules/@capacitor/status-bar/android')
+
+include ':capacitor-plugin-safe-area'
+project(':capacitor-plugin-safe-area').projectDir = new File('../node_modules/capacitor-plugin-safe-area/android')

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -19,6 +19,7 @@ def capacitor_pods
   pod 'CapacitorKeyboard', :path => '../../node_modules/@capacitor/keyboard'
   pod 'CapacitorPreferences', :path => '../../node_modules/@capacitor/preferences'
   pod 'CapacitorStatusBar', :path => '../../node_modules/@capacitor/status-bar'
+  pod 'CapacitorPluginSafeArea', :path => '../../node_modules/capacitor-plugin-safe-area'
 end
 
 target 'App' do

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -15,6 +15,8 @@ PODS:
     - Capacitor
   - CapacitorKeyboard (7.0.1):
     - Capacitor
+  - CapacitorPluginSafeArea (4.0.0):
+    - Capacitor
   - CapacitorPreferences (7.0.1):
     - Capacitor
   - CapacitorStatusBar (7.0.1):
@@ -30,6 +32,7 @@ DEPENDENCIES:
   - "CapacitorDevice (from `../../node_modules/@capacitor/device`)"
   - "CapacitorHaptics (from `../../node_modules/@capacitor/haptics`)"
   - "CapacitorKeyboard (from `../../node_modules/@capacitor/keyboard`)"
+  - CapacitorPluginSafeArea (from `../../node_modules/capacitor-plugin-safe-area`)
   - "CapacitorPreferences (from `../../node_modules/@capacitor/preferences`)"
   - "CapacitorStatusBar (from `../../node_modules/@capacitor/status-bar`)"
 
@@ -54,6 +57,8 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/haptics"
   CapacitorKeyboard:
     :path: "../../node_modules/@capacitor/keyboard"
+  CapacitorPluginSafeArea:
+    :path: "../../node_modules/capacitor-plugin-safe-area"
   CapacitorPreferences:
     :path: "../../node_modules/@capacitor/preferences"
   CapacitorStatusBar:
@@ -68,10 +73,11 @@ SPEC CHECKSUMS:
   CapacitorDevice: c6f6d587dd310527f8a48bf09c4e7b4a4cf14329
   CapacitorHaptics: 1f1e17041f435d8ead9ff2a34edd592c6aa6a8d6
   CapacitorKeyboard: 09fd91dcde4f8a37313e7f11bde553ad1ed52036
+  CapacitorPluginSafeArea: 22031c3436269ca80fac90ec2c94bc7c1e59a81d
   CapacitorPreferences: 6c98117d4d7508034a4af9db64d6b26fc75d7b94
   CapacitorStatusBar: 6e7af040d8fc4dd655999819625cae9c2d74c36f
   OSBarcodeLib: f2e981270a64faf476cb790864262b29ab8cd68a
 
-PODFILE CHECKSUM: 6575e15e7b9a8da66024a728758e8a57995c37a8
+PODFILE CHECKSUM: d47d682c4fd1334dc75c6c8e73f7271d1806b528
 
 COCOAPODS: 1.16.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/react-router": "5.1.20",
         "@types/react-router-dom": "5.3.3",
         "axios": "1.8.3",
+        "capacitor-plugin-safe-area": "4.0.0",
         "embla-carousel-react": "8.1.6",
         "ionicons": "7.0.0",
         "moment-timezone": "0.5.45",
@@ -4180,6 +4181,15 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/capacitor-plugin-safe-area": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/capacitor-plugin-safe-area/-/capacitor-plugin-safe-area-4.0.0.tgz",
+      "integrity": "sha512-5VHT4wG2TlwHtyy3zKrAjKwgJQgC3KeMfRW1bc8abTETLYNLxb85zvfpA0QFE59BxbtYHD57GvXKJuUPgEHl3g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
     },
     "node_modules/chai": {
       "version": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/react-router": "5.1.20",
     "@types/react-router-dom": "5.3.3",
     "axios": "1.8.3",
+    "capacitor-plugin-safe-area": "4.0.0",
     "embla-carousel-react": "8.1.6",
     "ionicons": "7.0.0",
     "moment-timezone": "0.5.45",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,8 +58,28 @@ import { ScanningProfilesScreen } from "./scanning/scanningOptions/screens/Scann
 import { UserProfileTab } from "./userProfile/screens/UserProfileScreen/UserProfileTab.jsx";
 import { setDarkModeInDocument } from "./common/common.lib.js";
 import { Source } from "./sources/screens/Source/Source";
+import { SafeArea } from "capacitor-plugin-safe-area";
 
 setupIonicReact();
+
+// Set CSS variables for the safe area insets using the SafeArea plugin
+// to fix capacitor safe area issues on android
+SafeArea.getSafeAreaInsets().then((data) => {
+  const { insets } = data;
+  document.body.style.setProperty("--ion-safe-area-top", `${insets.top}px`);
+  document.body.style.setProperty(
+    "--ion-safe-area-right",
+    `${insets.right}px`
+  );
+  document.body.style.setProperty(
+    "--ion-safe-area-bottom",
+    `${insets.bottom}px`
+  );
+  document.body.style.setProperty(
+    "--ion-safe-area-left",
+    `${insets.left}px`
+  );
+});
 
 /**
  * @param {Object} props

--- a/src/scanning/scanning.lib.js
+++ b/src/scanning/scanning.lib.js
@@ -113,7 +113,7 @@ export const getVegaPlotSpec = ({
     window.matchMedia("(prefers-color-scheme: dark)").matches;
   const mjdNow = Date.now() / 86400000.0 + 40587.0;
   return /** @type {any} */ ({
-    $schema: "https://vega.github.io/schema/vega-lite/v5.2.0.json",
+    $schema: "https://vega.github.io/schema/vega-lite/v6.json",
     background: "transparent",
     width: "container",
     height: "container",

--- a/src/scanning/scanningSession/components/CandidateList/CandidateList.jsx
+++ b/src/scanning/scanningSession/components/CandidateList/CandidateList.jsx
@@ -74,15 +74,9 @@ export const CandidateList = () => {
           isError ?
             "An error occurred while searching for candidates. Please try again." :
             "No candidates were found with the selected options. Please try again.",
-        buttons: [
-          {
-            text: "OK",
-            handler: () => {
-              history.back();
-            },
-          },
-        ],
+        buttons: ["OK"],
       })
+      history.back();
     }
   }, [isFetched, isError, totalMatches, presentAlert]);
   /** @type {import("../../../scanning.lib.js").Candidate[]|undefined} */
@@ -317,6 +311,10 @@ export const CandidateList = () => {
         break;
     }
   };
+
+  if (isFetched && (isError || totalMatches === 0)) {
+    return null;
+  }
 
   return (
     <div className="candidate-list">

--- a/src/sources/components/PinnedAnnotations/AnnotationsViewerModal.jsx
+++ b/src/sources/components/PinnedAnnotations/AnnotationsViewerModal.jsx
@@ -12,7 +12,7 @@ export const AnnotationsViewerModal = ({ source, modal }) => {
     <IonModal
       ref={modal}
       initialBreakpoint={0.75}
-      breakpoints={[0.75, 1]}
+      breakpoints={[0, 0.75, 1]}
     >
       <IonHeader>
         <IonSearchbar />

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -122,7 +122,3 @@ http://ionicframework.com/docs/theming/ */
   --ion-color-light-tint: #292c2d;
 
 }
-
-ion-router-outlet {
-  padding-bottom: calc(2.6rem + var(--ion-safe-area-top));
-}


### PR DESCRIPTION
– Fix safe area insets on Android using capacitor-plugin-safe-area.
– Update Vega-Lite schema version to v6 in scanning.lib.js to fix version mismatch with Vega-Lite.
– Adjust IonModal breakpoints to allow closing modal by swiping and remove unnecessary padding in variables.scss.
– Directly navigate back when no candidates are found and return null instead of rendering HTML content.